### PR TITLE
Fixed long delay bug and minor doc improvements

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -92,7 +92,7 @@ public:
   // Neither Sanyo nor Mitsubishi send is implemented yet
   //  void sendSanyo(unsigned long data, int nbits);
   //  void sendMitsubishi(unsigned long data, int nbits);
-  void sendRaw(unsigned int buf[], int len, int hz);
+  void sendRaw(unsigned int buf[], int len, int khz);
   void sendRC5(unsigned long data, int nbits);
   void sendRC6(unsigned long data, int nbits);
   void sendDISH(unsigned long data, int nbits);


### PR DESCRIPTION
Hello. I made a few minor improvements to Arduino-IRremote.

The delay thing, in case you're wondering, came up because [I was trying to control a Lutron GrafikEye lighting controller](http://www.flickr.com/photos/laurence/7966467276/in/photostream), and one of the "marks" it expects is about 20ms, which is way longer than Arduino's delayMicroseconds is documented to support (and actually, I only learned this after witnessing my Diecimila "misbehave").

The naming/doc changes were in response to things that tripped me up, or forced me to carefully read the implementation.

```
- Delays longer than 16383us were unreliable, due to a quirk/bug in
  Arduino's delayMicroseconds.

- Some parameters that were meant to hold kHz values were named "hz", so
  renamed them to "khz".

- The meaning of sendRaw's buf parameter wasn't obvious to me, so I
  added a comment explaining it.
```
