### PR TITLE
Add IRrecv::decode which accepts only one encoding.

### DIFF
--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -380,17 +380,22 @@ void IRrecv::resume() {
   irparams.rawlen = 0;
 }
 
-
+int IRrecv::decodeStart(decode_results *results)
+{
+  results->rawbuf = irparams.rawbuf;
+  results->rawlen = irparams.rawlen;
+  if (irparams.rcvstate != STATE_STOP)
+    return ERR;
+  return DECODED;
+}
 
 // Decodes the received IR message
 // Returns 0 if no data ready, 1 if data ready.
 // Results of decoding are stored in results
 int IRrecv::decode(decode_results *results) {
-  results->rawbuf = irparams.rawbuf;
-  results->rawlen = irparams.rawlen;
-  if (irparams.rcvstate != STATE_STOP) {
+  if (decodeStart(results) == ERR)
     return ERR;
-  }
+
 #ifdef DEBUG
   Serial.println("Attempting NEC decode");
 #endif

--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -389,6 +389,12 @@ int IRrecv::decodeStart(decode_results *results)
   return DECODED;
 }
 
+#ifdef DEBUG
+#define debug_println Serial.println
+#else
+#define debug_println (void)
+#endif
+
 // Decodes the received IR message
 // Returns 0 if no data ready, 1 if data ready.
 // Results of decoding are stored in results
@@ -396,54 +402,46 @@ int IRrecv::decode(decode_results *results) {
   if (decodeStart(results) == ERR)
     return ERR;
 
-#ifdef DEBUG
-  Serial.println("Attempting NEC decode");
-#endif
+  debug_println("Attempting NEC decode");
   if (decodeNEC(results)) {
     return DECODED;
   }
-#ifdef DEBUG
-  Serial.println("Attempting Sony decode");
-#endif
+
+  debug_println("Attempting Sony decode");
   if (decodeSony(results)) {
     return DECODED;
   }
-#ifdef DEBUG
-  Serial.println("Attempting Sanyo decode");
-#endif
+
+  debug_println("Attempting Sanyo decode");
   if (decodeSanyo(results)) {
     return DECODED;
   }
-#ifdef DEBUG
-  Serial.println("Attempting Mitsubishi decode");
-#endif
+
+  debug_println("Attempting Mitsubishi decode");
   if (decodeMitsubishi(results)) {
     return DECODED;
   }
-#ifdef DEBUG
-  Serial.println("Attempting RC5 decode");
-#endif  
+
+  debug_println("Attempting RC5 decode");
   if (decodeRC5(results)) {
     return DECODED;
   }
-#ifdef DEBUG
-  Serial.println("Attempting RC6 decode");
-#endif 
+
+  debug_println("Attempting RC6 decode");
   if (decodeRC6(results)) {
     return DECODED;
   }
-#ifdef DEBUG
-    Serial.println("Attempting Panasonic decode");
-#endif 
-    if (decodePanasonic(results)) {
-        return DECODED;
-    }
-#ifdef DEBUG
-    Serial.println("Attempting JVC decode");
-#endif 
-    if (decodeJVC(results)) {
-        return DECODED;
-    }
+
+  debug_println("Attempting Panasonic decode");
+  if (decodePanasonic(results)) {
+    return DECODED;
+  }
+
+  debug_println("Attempting JVC decode");
+  if (decodeJVC(results)) {
+    return DECODED;
+  }
+
   // decodeHash returns a hash on any input.
   // Thus, it needs to be last in the list.
   // If you add any decodes, add them before this.
@@ -720,14 +718,14 @@ int IRrecv::getRClevel(decode_results *results, int *offset, int *used, int t1) 
     *used = 0;
     (*offset)++;
   }
-#ifdef DEBUG
+
   if (val == MARK) {
-    Serial.println("MARK");
+    debug_println("MARK");
   } 
   else {
-    Serial.println("SPACE");
+    debug_println("SPACE");
   }
-#endif
+
   return val;   
 }
 

--- a/IRremote.h
+++ b/IRremote.h
@@ -50,6 +50,9 @@ public:
 // Decoded value for NEC when a repeat code is received
 #define REPEAT 0xffffffff
 
+#define ERR 0
+#define DECODED 1
+
 // main class for receiving IR
 class IRrecv
 {
@@ -59,6 +62,29 @@ public:
   int decode(decode_results *results);
   void enableIRIn();
   void resume();
+
+  // "always_inline" to force compiling out all encodings other than "type"
+  int decode(int type, decode_results *results) __attribute__((always_inline)) {
+    if (decodeStart(results) == ERR)
+      return ERR;
+
+    switch (type)
+    {
+    case NEC:        if (decodeNEC(results))        return DECODED; break;
+    case SONY:       if (decodeSony(results))       return DECODED; break;
+    case RC5:        if (decodeRC5(results))        return DECODED; break;
+    case RC6:        if (decodeRC6(results))        return DECODED; break;
+    case PANASONIC:  if (decodePanasonic(results))  return DECODED; break;
+    case JVC:        if (decodeJVC(results))        return DECODED; break;
+    case SANYO:      if (decodeSanyo(results))      return DECODED; break;
+    case MITSUBISHI: if (decodeMitsubishi(results)) return DECODED; break;
+    case UNKNOWN:    if (decodeHash(results))       return DECODED; break;
+    }
+
+    resume();
+    return ERR;
+  }
+
 private:
   // These are called by decode
   int getRClevel(decode_results *results, int *offset, int *used, int t1);
@@ -72,7 +98,7 @@ private:
   long decodeJVC(decode_results *results);
   long decodeHash(decode_results *results);
   int compare(unsigned int oldval, unsigned int newval);
-
+  int decodeStart(decode_results *results);
 } 
 ;
 

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -75,10 +75,6 @@
 #define SYSCLOCK 16000000  // main Arduino clock
 #endif
 
-#define ERR 0
-#define DECODED 1
-
-
 // defines for setting and clearing register bits
 #ifndef cbi
 #define cbi(sfr, bit) (_SFR_BYTE(sfr) &= ~_BV(bit))


### PR DESCRIPTION
As I explained in the commit: it can be used to reduce library overhead when only one type encoding is used - all code handling other encodings is optimized out.
