### PR TITLE
Added ability to use active-high IR receivers with 2nd (optional) argument to IRrecv().  Still defaults to active-low.

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -20,7 +20,7 @@
 // If DEBUG is defined, a lot of debugging output will be printed during decoding.
 // TEST must be defined for the IRtest unittests to work.  It will make some
 // methods virtual, which will be slightly slower, which is why it is optional.
-// #define DEBUG
+//#define DEBUG
 // #define TEST
 
 // Results returned from the decoder
@@ -55,6 +55,7 @@ class IRrecv
 {
 public:
   IRrecv(int recvpin);
+  IRrecv(int recvpin, int mark_val);
   void blink13(int blinkflag);
   int decode(decode_results *results);
   void enableIRIn();

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -196,15 +196,12 @@ typedef struct {
   unsigned int timer;     // state timer, counts 50uS ticks.
   unsigned int rawbuf[RAWBUF]; // raw data
   uint8_t rawlen;         // counter of entries in rawbuf
+  uint8_t mark_val;       // 0 = active-low, 1 = active-high
 } 
 irparams_t;
 
 // Defined in IRremote.cpp
 extern volatile irparams_t irparams;
-
-// IR detector output is active low
-#define MARK  0
-#define SPACE 1
 
 #define TOPBIT 0x80000000
 


### PR DESCRIPTION
If one argument is provided to IRrecv(), then the input defaults to active-low.
If two arguments are provided to IRrecv(), the 2nd argument is the sense of the IR receiver (0 = active-low, 1 = active-high).
