### PR TITLE
WIP: Add support for Fujitsu heat pumps

### DIFF
--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -914,37 +914,20 @@ long IRrecv::decodeFujitsu(decode_results *results) {
         return ERR;
     }
 
-    int temp = 0;
-
-    for(int i=0; i<4; i++) results->data[i] = 0;
+    for(int i=0; i<DATA_SIZE; i++) results->data[i] = 0;
+    int bits = (results->rawlen - 4) / 2;
 
     // decode address
-    for (int i = 0; i < FUJITSU_BITS; i++) {
+    for (int i = 0; i < bits; i++) {
         if (!MATCH_MARK(results->rawbuf[offset++],FUJITSU_MARK)) {
             return ERR;
         }
 
+        int index = i / (sizeof(char) * 8);
         if (MATCH_SPACE(results->rawbuf[offset],FUJITSU_ONE_SPACE)) {
-            if(i == 68){
-              Serial.print("*");
-            }
-            Serial.print("1");
-            if(i == 71){
-              Serial.print("*");
-            }
-            if(i >= 68 && i <= 71){
-              temp += (1<<(i - 68));
-            }
-            results->data[i/32] = (results->data[i/32] << 1) | 1;
+            results->data[index] = (results->data[index] << 1) | 1;
         } else if (MATCH_SPACE(results->rawbuf[offset],FUJITSU_ZERO_SPACE)) {
-            if(i == 68){
-              Serial.print("*");
-            }
-            Serial.print("0");
-            if(i == 71){
-              Serial.print("*");
-            }
-            results->data[i/32] <<= 1;
+            results->data[index] <<= 1;
         } else {
             Serial.print("ERR");
             Serial.print(i, DEC);
@@ -953,13 +936,8 @@ long IRrecv::decodeFujitsu(decode_results *results) {
         offset++;
     }
 
-    Serial.println("");
-    Serial.print("Temp: ");
-    Serial.println(temp + 16, DEC);
-
-    results->value = (unsigned long) 0;
     results->decode_type = PANASONIC;
-    results->bits = 0;
+    results->bits = bits;
     return DECODED;
 }
 

--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -941,6 +941,28 @@ long IRrecv::decodeFujitsu(decode_results *results) {
     return DECODED;
 }
 
+void IRsend::sendFujitsu(unsigned char data[16], int nbits) {
+    enableIROut(38);
+    mark(FUJITSU_HDR_MARK);
+    space(FUJITSU_HDR_SPACE);
+
+    for (int i = 0; i < nbits; i++) {
+        mark(FUJITSU_MARK);
+
+        int index = i / (sizeof(char) * 8);
+        int bitVal = bitRead(data[index], i % 8);
+        if(bitVal == 1){
+          space(FUJITSU_ONE_SPACE);
+        }
+        else{
+          space(FUJITSU_ZERO_SPACE);
+        }
+    }
+
+    mark(FUJITSU_MARK);
+    space(0);
+}
+
 /* -----------------------------------------------------------------------
  * hashdecode - decode an arbitrary IR code.
  * Instead of decoding using a standard encoding scheme

--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -925,9 +925,9 @@ long IRrecv::decodeFujitsu(decode_results *results) {
 
         int index = i / (sizeof(char) * 8);
         if (MATCH_SPACE(results->rawbuf[offset],FUJITSU_ONE_SPACE)) {
-            results->data[index] = (results->data[index] << 1) | 1;
+            bitWrite(results->data[index], i % 8, 1);
         } else if (MATCH_SPACE(results->rawbuf[offset],FUJITSU_ZERO_SPACE)) {
-            results->data[index] <<= 1;
+            bitWrite(results->data[index], i % 8, 0);
         } else {
             Serial.print("ERR");
             Serial.print(i, DEC);

--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -936,7 +936,7 @@ long IRrecv::decodeFujitsu(decode_results *results) {
         offset++;
     }
 
-    results->decode_type = PANASONIC;
+    results->decode_type = FUJITSU;
     results->bits = bits;
     return DECODED;
 }

--- a/IRremote.h
+++ b/IRremote.h
@@ -104,6 +104,7 @@ public:
   void sendSharp(unsigned long data, int nbits);
   void sendPanasonic(unsigned int address, unsigned long data);
   void sendJVC(unsigned long data, int nbits, int repeat); // *Note instead of sending the REPEAT constant if you want the JVC repeat signal sent, send the original code value and change the repeat argument from 0 to 1. JVC protocol repeats by skipping the header NOT by sending a separate code value like NEC does.
+  void sendFujitsu(unsigned char data[], int nbits);
   // private:
   void enableIROut(int khz);
   VIRTUAL void mark(int usec);

--- a/IRremote.h
+++ b/IRremote.h
@@ -23,12 +23,14 @@
 // #define DEBUG
 // #define TEST
 
+#define DATA_SIZE 16
+
 // Results returned from the decoder
 class decode_results {
 public:
   int decode_type; // NEC, SONY, RC5, UNKNOWN
   unsigned int panasonicAddress; // This is only used for decoding Panasonic data
-  unsigned long data[4]; // This is only used for storing the data from Fujitsu remotes
+  unsigned char data[DATA_SIZE]; // This is currently only used for storing the data from Fujitsu remotes
   unsigned long value; // Decoded value
   int bits; // Number of bits in decoded value
   volatile unsigned int *rawbuf; // Raw intervals in .5 us ticks

--- a/IRremote.h
+++ b/IRremote.h
@@ -48,6 +48,7 @@ public:
 #define JVC 8
 #define SANYO 9
 #define MITSUBISHI 10
+#define FUJITSU 11
 #define UNKNOWN -1
 
 // Decoded value for NEC when a repeat code is received

--- a/IRremote.h
+++ b/IRremote.h
@@ -28,6 +28,7 @@ class decode_results {
 public:
   int decode_type; // NEC, SONY, RC5, UNKNOWN
   unsigned int panasonicAddress; // This is only used for decoding Panasonic data
+  unsigned long data[4]; // This is only used for storing the data from Fujitsu remotes
   unsigned long value; // Decoded value
   int bits; // Number of bits in decoded value
   volatile unsigned int *rawbuf; // Raw intervals in .5 us ticks
@@ -70,6 +71,7 @@ private:
   long decodeRC6(decode_results *results);
   long decodePanasonic(decode_results *results);
   long decodeJVC(decode_results *results);
+  long decodeFujitsu(decode_results *results);
   long decodeHash(decode_results *results);
   int compare(unsigned int oldval, unsigned int newval);
 
@@ -109,7 +111,7 @@ public:
 // Some useful constants
 
 #define USECPERTICK 50  // microseconds per clock interrupt tick
-#define RAWBUF 100 // Length of raw duration buffer
+#define RAWBUF 300 // Length of raw duration buffer
 
 // Marks tend to be 100us too long, and spaces 100us too short
 // when received due to sensor lag.

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -22,6 +22,8 @@
 #include <WProgram.h>
 #endif
 
+//#define DEBUG
+
 // define which timer to use
 //
 // Uncomment the timer you wish to use on your board.  If you
@@ -162,6 +164,13 @@
 #define JVC_ZERO_SPACE 550
 #define JVC_RPT_LENGTH 60000
 
+#define FUJITSU_HDR_MARK 3300
+#define FUJITSU_HDR_SPACE 1600
+#define FUJITSU_MARK 400
+#define FUJITSU_ZERO_SPACE 400
+#define FUJITSU_ONE_SPACE 1400
+#define FUJITSU_BITS 128
+
 #define SHARP_BITS 15
 #define DISH_BITS 16
 
@@ -195,7 +204,7 @@ typedef struct {
   uint8_t blinkflag;         // TRUE to enable blinking of pin 13 on IR processing
   unsigned int timer;     // state timer, counts 50uS ticks.
   unsigned int rawbuf[RAWBUF]; // raw data
-  uint8_t rawlen;         // counter of entries in rawbuf
+  uint16_t rawlen;         // counter of entries in rawbuf
 } 
 irparams_t;
 


### PR DESCRIPTION
I have added support to this library for my Fujitsu ASTG12LVCC air conditioner (with AR-RAH1E remote). My suspicion is that the code written so far is generic to many Fujitsu products.

Basically, the code is capable of recognizing and decoding a Fujitsu IR packet and making available the underlying (usually 128 bit) data. It can also send.

Here is an example (not quite working perfectly) of an Arduino application using this functionality to decode data (temperature, mode, fan speed) from such a device, and resend the packet.

This is a bit of a work in progress - I have figured out how the checksum is calculated and might want to add that to this.

I hope this work may be helpful to someone else who wants to (perhaps) control their AC unit with an Arduino!