### PR TITLE
TIMER4 Arduino Pro Micro compatibility

### DIFF
--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -339,14 +339,14 @@ extern volatile irparams_t irparams;
 // defines for timer4 (10 bits, high speed option)
 #elif defined(IR_USE_TIMER4_HS)
 #define TIMER_RESET
-#define TIMER_ENABLE_PWM     (TCCR4A |= _BV(COM4A1))
-#define TIMER_DISABLE_PWM    (TCCR4A &= ~(_BV(COM4A1)))
+#define TIMER_ENABLE_PWM     (TCCR4A |= _BV(COM4B1))
+#define TIMER_DISABLE_PWM    (TCCR4A &= ~(_BV(COM4B1)))
 #define TIMER_ENABLE_INTR    (TIMSK4 = _BV(TOIE4))
 #define TIMER_DISABLE_INTR   (TIMSK4 = 0)
 #define TIMER_INTR_NAME      TIMER4_OVF_vect
 #define TIMER_CONFIG_KHZ(val) ({ \
   const uint16_t pwmval = SYSCLOCK / 2000 / (val); \
-  TCCR4A = (1<<PWM4A); \
+  TCCR4A = (1<<PWM4B); \
   TCCR4B = _BV(CS40); \
   TCCR4C = 0; \
   TCCR4D = (1<<WGM40); \
@@ -354,7 +354,7 @@ extern volatile irparams_t irparams;
   TC4H = pwmval >> 8; \
   OCR4C = pwmval; \
   TC4H = (pwmval / 3) >> 8; \
-  OCR4A = (pwmval / 3) & 255; \
+  OCR4B = (pwmval / 3) & 255; \
 })
 #define TIMER_CONFIG_NORMAL() ({ \
   TCCR4A = 0; \
@@ -367,10 +367,10 @@ extern volatile irparams_t irparams;
   TC4H = 0; \
   TCNT4 = 0; \
 })
-#if defined(CORE_OC4A_PIN)
-#define TIMER_PWM_PIN        CORE_OC4A_PIN  /* Teensy */
+#if defined(CORE_OC4B_PIN)
+#define TIMER_PWM_PIN        CORE_OC4B_PIN  /* Teensy */
 #elif defined(__AVR_ATmega32U4__)
-#define TIMER_PWM_PIN        13  /* Leonardo */
+#define TIMER_PWM_PIN        10  /* Leonardo */
 #else
 #error "Please add OC4A pin number here\n"
 #endif


### PR DESCRIPTION
Change PWM pin 13 (OC4A) to pin 10 (OC4B) on ATmega32u4-based Arduino. Pin 13 is not broken out on Arduino Pro Micro.

Keep in mind that it will probably break compatibility with some existing applications. It's up to maintainer to merge it or not.