### PR TITLE
Added the possibility to 'control' the amount of sensor usec lag (MARK_E...

### DIFF
--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -305,7 +305,7 @@ IRrecv::IRrecv(int recvpin, unsigned int senzorLag) : IRrecv(recvpin)
 	gMarkExcess = senzorLag;
 }
 
-bool IRrecv::setAtomicRead(bool readAllTransmission)
+void IRrecv::setAtomicRead(bool readAllTransmission)
 {
 	gAtomicRead = readAllTransmission;
 }

--- a/IRremote.h
+++ b/IRremote.h
@@ -66,7 +66,7 @@ public:
   int decode(decode_results *results);
   void enableIRIn();
   void resume();
-  bool setAtomicRead(bool readAllTransmission);
+  void setAtomicRead(bool readAllTransmission);
   static unsigned int gMarkExcess;
   static bool gAtomicRead;
 

--- a/IRremote.h
+++ b/IRremote.h
@@ -61,10 +61,15 @@ class IRrecv
 {
 public:
   IRrecv(int recvpin);
+  IRrecv(int recvpin, unsigned int markExcess);
   void blink13(int blinkflag);
   int decode(decode_results *results);
   void enableIRIn();
   void resume();
+  bool setAtomicRead(bool readAllTransmission);
+  static unsigned int gMarkExcess;
+  static bool gAtomicRead;
+
 private:
   // These are called by decode
   int getRClevel(decode_results *results, int *offset, int *used, int t1);


### PR DESCRIPTION
I've been using this library together with FastLed for ws2812, which uses heavy calculations for time sync. It disables quite often the interrupts affecting IRremote timer, therefore it breaks beyond recognition the read signals.

A second issue that I had is related to the MARK_EXCESS "correction" which seems to break the signal detection (at least for my KEYES remote kit).

I have added the possibility to 'control' the amount of sensor usec lag (MARK_EXCESS) used in calculations and added an option to read the entire transmission within the interrupt call, to avoid other libraries interference with calls to cli or sei.
