### PR TITLE
Updates to IRremote.h, irSend.cpp

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -255,9 +255,9 @@ class IRsend
 
 		void  custom_delay_usec (unsigned long uSecs);
 		void  enableIROut 		(int khz) ;
-		void  mark        		(int usec) ;
-		void  space       		(int usec) ;
-		void  sendRaw     		(unsigned int buf[],  unsigned char len,  unsigned char hz) ;
+		void  mark        		(unsigned int usec) ;
+		void  space       		(unsigned int usec) ;
+		void  sendRaw     		(unsigned int buf[],  unsigned int len,  unsigned int hz) ;
 
 		//......................................................................
 #		if SEND_RC5

--- a/irSend.cpp
+++ b/irSend.cpp
@@ -2,12 +2,12 @@
 #include "IRremoteInt.h"
 
 //+=============================================================================
-void  IRsend::sendRaw (unsigned int buf[],  unsigned char len,  unsigned char hz)
+void  IRsend::sendRaw (unsigned int buf[],  unsigned int len,  unsigned int hz)
 {
 	// Set IR carrier frequency
 	enableIROut(hz);
 
-	for (unsigned char i = 0;  i < len;  i++) {
+	for (unsigned int i = 0;  i < len;  i++) {
 		if (i & 1)  space(buf[i]) ;
 		else        mark (buf[i]) ;
 	}
@@ -19,7 +19,7 @@ void  IRsend::sendRaw (unsigned int buf[],  unsigned char len,  unsigned char hz
 // Sends an IR mark for the specified number of microseconds.
 // The mark output is modulated at the PWM frequency.
 //
-void  IRsend::mark (int time)
+void  IRsend::mark (unsigned int time)
 {
 	TIMER_ENABLE_PWM; // Enable pin 3 PWM output
 	if (time > 0) custom_delay_usec(time);
@@ -30,7 +30,7 @@ void  IRsend::mark (int time)
 // Sends an IR space for the specified number of microseconds.
 // A space is no output, so the PWM output is disabled.
 //
-void  IRsend::space (int time)
+void  IRsend::space (unsigned int time)
 {
 	TIMER_DISABLE_PWM; // Disable pin 3 PWM output
 	if (time > 0) IRsend::custom_delay_usec(time);
@@ -79,8 +79,9 @@ void IRsend::custom_delay_usec(unsigned long uSecs) {
       while ( micros() > start ) {} // wait until overflow
     }
     while ( micros() < endMicros ) {} // normal wait
-  } else {
-    __asm__("nop\n\t"); // must have or compiler optimizes out
-  }
+  } 
+  //else {
+  //  __asm__("nop\n\t"); // must have or compiler optimizes out
+  //}
 }
 


### PR DESCRIPTION
Allows, longer marks, spaces by using unsigned int in function parameters
Allows longer signals, reversing a recent change which limited the max signal length to 255, using sendRAW.
Reversed the 'asm' workaround recently made to custom_delay_usec, as removing this workaround does not cause a problem on my Arduino IDE (1.6.5-r2). The original author should check again - maybe there are special compiler optimixzations at play? Alternatively, try using the 'volatile' keyword before the function variables, to prevent the code being optimized out???.

I have tested these changes and verified correct operation on Arduino  IDE (1.6.5-r2) & oscilloscope.