### PR TITLE
Update IRsendDemo.ino

### DIFF
--- a/examples/IRsendDemo/IRsendDemo.ino
+++ b/examples/IRsendDemo/IRsendDemo.ino
@@ -20,4 +20,5 @@ void loop() {
 		irsend.sendSony(0xa90, 12);
 		delay(40);
 	}
+	delay(5000); //5 second delay between each signal burst
 }


### PR DESCRIPTION
As written this example will cause issues with some IR receivers. On the face of it it sends the Sony signal burst 3 times with a 40ms gap. However, it really continues to send the sony signal forever with a 40ms gap.

There needs to be a reasonable gap between signals sent & I have added in a 5 sec gap as a reasonable figure.

Without a longer gap, many IR receivers will treat this signal as noise as it send continuous Sony bursts with a 40 ms gap.