### PR TITLE
Bug fixes as per Issue #167

### DIFF
--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -10,7 +10,12 @@
 
 #include <IRremote.h>
 
-int RECV_PIN = 11;
+/* 
+*  Default is Arduino pin D11. 
+*  You can change this to another available Arduino Pin.
+*  Your IR receiver should be connected to the pin defined here
+*/
+int RECV_PIN = 11; 
 
 IRrecv irrecv(RECV_PIN);
 
@@ -22,18 +27,17 @@ void setup()
   irrecv.enableIRIn(); // Start the receiver
 }
 
-// Dumps out the decode_results structure.
-// Call this after IRrecv::decode()
-// void * to work around compiler issue
-//void dump(void *v) {
-//  decode_results *results = (decode_results *)v
+
 void dump(decode_results *results) {
+  // Dumps out the decode_results structure.
+  // Call this after IRrecv::decode()
   int count = results->rawlen;
   if (results->decode_type == UNKNOWN) {
     Serial.print("Unknown encoding: ");
   }
   else if (results->decode_type == NEC) {
     Serial.print("Decoded NEC: ");
+
   }
   else if (results->decode_type == SONY) {
     Serial.print("Decoded SONY: ");
@@ -46,21 +50,20 @@ void dump(decode_results *results) {
   }
   else if (results->decode_type == PANASONIC) {
     Serial.print("Decoded PANASONIC - Address: ");
-    Serial.print(results->address,HEX);
+    Serial.print(results->address, HEX);
     Serial.print(" Value: ");
   }
   else if (results->decode_type == LG) {
-     Serial.print("Decoded LG: ");
+    Serial.print("Decoded LG: ");
   }
   else if (results->decode_type == JVC) {
-     Serial.print("Decoded JVC: ");
-
+    Serial.print("Decoded JVC: ");
   }
   else if (results->decode_type == AIWA_RC_T501) {
     Serial.print("Decoded AIWA RC T501: ");
   }
   else if (results->decode_type == WHYNTER) {
-     Serial.print("Decoded Whynter: ");
+    Serial.print("Decoded Whynter: ");
   }
   Serial.print(results->value, HEX);
   Serial.print(" (");
@@ -70,18 +73,18 @@ void dump(decode_results *results) {
   Serial.print(count, DEC);
   Serial.print("): ");
 
-  for (int i = 0; i < count; i++) {
-    if ((i % 2) == 1) {
+  for (int i = 1; i < count; i++) {
+    if (i & 1) {
       Serial.print(results->rawbuf[i]*USECPERTICK, DEC);
     }
     else {
-      Serial.print(-(int)results->rawbuf[i]*USECPERTICK, DEC);
+      Serial.write('-');
+      Serial.print((unsigned long) results->rawbuf[i]*USECPERTICK, DEC);
     }
     Serial.print(" ");
   }
-  Serial.println("");
+  Serial.println();
 }
-
 
 void loop() {
   if (irrecv.decode(&results)) {

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 // Tell IRremote which Arduino pin is connected to the IR Receiver (TSOP4838)
 //
-int recvPin = 6;
+int recvPin = 11;
 IRrecv irrecv(recvPin);
 
 //+=============================================================================
@@ -92,10 +92,9 @@ void  dumpRaw (decode_results *results)
   Serial.print("Timing[");
   Serial.print(results->rawlen, DEC);
   Serial.println("]: ");
-  Serial.print("     -");
-  Serial.println(results->rawbuf[0] * USECPERTICK, DEC);
+
   for (int i = 1;  i < results->rawlen;  i++) {
-    unsigned int  x = results->rawbuf[i] * USECPERTICK;
+    unsigned long  x = results->rawbuf[i] * USECPERTICK;
     if (!(i & 1)) {  // even
       Serial.print("-");
       if (x < 1000)  Serial.print(" ") ;
@@ -109,7 +108,7 @@ void  dumpRaw (decode_results *results)
       Serial.print(x, DEC);
       Serial.print(", ");
     }
-    if (!(i%8))  Serial.println("");
+    if (!(i % 8))  Serial.println("");
   }
   Serial.println("");                    // Newline
 }
@@ -126,10 +125,10 @@ void  dumpCode (decode_results *results)
   Serial.print("] = {");                   // Start declaration
 
   // Dump data
-  for (int i = 0;  i < results->rawlen;  i++) {
+  for (int i = 1;  i < results->rawlen;  i++) {
     Serial.print(results->rawbuf[i] * USECPERTICK, DEC);
     Serial.print(",");
-    if (!(i&1))  Serial.print(" ");
+    if (!(i & 1))  Serial.print(" ");
   }
 
   // End declaration
@@ -143,17 +142,17 @@ void  dumpCode (decode_results *results)
 
   // Newline
   Serial.println("");
-  
+
   // Now dump "known" codes
   if (results->decode_type != UNKNOWN) {
-    
+
     // Some protocols have an address
     if (results->decode_type == PANASONIC) {
       Serial.print("unsigned int  addr = 0x");
       Serial.print(results->address, HEX);
       Serial.println(";");
     }
-    
+
     // All protocols have data
     Serial.print("unsigned int  data = 0x");
     Serial.print(results->value, HEX);
@@ -166,14 +165,13 @@ void  dumpCode (decode_results *results)
 //
 void  loop ( )
 {
-    decode_results  results;        // Somewhere to store the results
+  decode_results  results;        // Somewhere to store the results
 
-    if (irrecv.decode(&results)) {  // Grab an IR code
-      dumpInfo(&results);           // Output the results
-      dumpRaw(&results);            // Output the results in RAW format
-      dumpCode(&results);           // Output the results as source code
-      Serial.println("");           // Blank line between entries
-      irrecv.resume();              // Prepare for the next value
-    }
+  if (irrecv.decode(&results)) {  // Grab an IR code
+    dumpInfo(&results);           // Output the results
+    dumpRaw(&results);            // Output the results in RAW format
+    dumpCode(&results);           // Output the results as source code
+    Serial.println("");           // Blank line between entries
+    irrecv.resume();              // Prepare for the next value
+  }
 }
-


### PR DESCRIPTION
Have updated IRrecvDdump to fix bugs described in Issue: #167

In summary, removed bug where large space values were displayed incorrectly & confusing users. The output now always starts with a mark, instead of a space, which makes it easier to interpret and less confusing for users.

refer to #167 for more detials.

The update has been tested with several protocols (but not all) and verified as working.