### PR TITLE
Change definition of IRsend::sendRaw array parameter to const

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -257,7 +257,7 @@ class IRsend
 		void  enableIROut 		(int khz) ;
 		void  mark        		(unsigned int usec) ;
 		void  space       		(unsigned int usec) ;
-		void  sendRaw     		(unsigned int buf[],  unsigned int len,  unsigned int hz) ;
+		void  sendRaw     		(const unsigned int buf[],  unsigned int len,  unsigned int hz) ;
 
 		//......................................................................
 #		if SEND_RC5

--- a/irSend.cpp
+++ b/irSend.cpp
@@ -2,7 +2,7 @@
 #include "IRremoteInt.h"
 
 //+=============================================================================
-void  IRsend::sendRaw (unsigned int buf[],  unsigned int len,  unsigned int hz)
+void  IRsend::sendRaw (const unsigned int buf[],  unsigned int len,  unsigned int hz)
 {
 	// Set IR carrier frequency
 	enableIROut(hz);


### PR DESCRIPTION
Change definition of IRsend::sendRaw method array parameter to const to allow passing constant array to function. This would allow passing const arrays to the method.