### PR TITLE
Add Seiki TV Send Support

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -76,6 +76,9 @@
 #define DECODE_PRONTO        0 // This function doe not logically make sense
 #define SEND_PRONTO          1
 
+#define DECODE_SEIKI        0 // NOT WRITTEN
+#define SEND_SEIKI          1
+
 //------------------------------------------------------------------------------
 // When sending a Pronto code we request to send either the "once" code
 //                                                   or the "repeat" code
@@ -115,6 +118,7 @@ typedef
 		SHARP,
 		DENON,
 		PRONTO,
+		SEIKI,
 	}
 decode_type_t;
 
@@ -242,6 +246,10 @@ class IRrecv
 #		if DECODE_DENON
 			bool  decodeDenon (decode_results *results) ;
 #		endif
+		//......................................................................
+#		if DECODE_SEIKI
+			bool  decodeSeiki (decode_results *results) ;
+#		endif
 } ;
 
 //------------------------------------------------------------------------------
@@ -324,6 +332,10 @@ class IRsend
 		//......................................................................
 #		if SEND_Pronto
 			void  sendPronto     (char* code,  bool repeat,  bool fallback) ;
+#		endif
+		//......................................................................
+#		if SEND_SEIKI
+			void  sendSeiki      (unsigned long data,  int nbits) ;
 #		endif
 } ;
 

--- a/ir_Seiki.cpp
+++ b/ir_Seiki.cpp
@@ -1,0 +1,58 @@
+#include "IRremote.h"
+#include "IRremoteInt.h"
+
+//==============================================================================
+//
+//
+//                              S E I K I
+//
+//
+//==============================================================================
+
+#define SEIKI_BITS        16  // The number of bits in the command
+
+#define SEIKI_HDR_MARK    9057 // The length of the Header:Mark
+#define SEIKI_HDR_SPACE   4467 // The length of the Header:Space
+
+#define SEIKI_BIT_MARK    606  // The length of a Bit:Mark
+#define SEIKI_ONE_SPACE   1646  // The length of a Bit:Space for 1's
+#define SEIKI_ZERO_SPACE  520  // The length of a Bit:Space for 0's
+
+
+//+=============================================================================
+//
+#if SEND_SEIKI
+void  IRsend::sendSeiki (unsigned long data,  int nbits)
+{
+	// Set IR carrier frequency
+	enableIROut(38);
+
+	unsigned long pre = 0x40BE;  // 16 bits
+
+	// Header
+	mark (SEIKI_HDR_MARK);
+	space(SEIKI_HDR_SPACE);
+
+    // Send "pre" data
+	for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+		mark(SEIKI_BIT_MARK);
+		if (pre & mask)  space(SEIKI_ONE_SPACE) ;
+		else             space(SEIKI_ZERO_SPACE) ;
+	}
+
+	// Data
+	for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+		if (data & mask) {
+			mark (SEIKI_BIT_MARK);
+			space(SEIKI_ONE_SPACE);
+		} else {
+			mark (SEIKI_BIT_MARK);
+			space(SEIKI_ZERO_SPACE);
+		}
+	}
+
+	// Footer
+	mark(SEIKI_BIT_MARK);
+    space(0);  // Always end with the LED off
+}
+#endif


### PR DESCRIPTION
Add Seiki Support based on lirc.conf. Confirmed working

Predata based on AIWA, so thanks for that.

```
# Please make this file available to others
# by sending it to <lirc@bartelmus.de>
#
# this config file was automatically generated
                                                                                                                                                                                 24,1           2%

# Please make this file available to others
# by sending it to <lirc@bartelmus.de>
#
# this config file was automatically generated
# using lirc-0.9.0-pre1(default) on Tue Oct 20 08:30:27 2015
#
# contributed by
#
# brand:                       /root/lircd.conf
# model no. of remote control:
# devices being controlled by this remote:
#

begin remote

  name   seiki
  bits           16
  flags SPACE_ENC|CONST_LENGTH
  eps            30
  aeps          100

  header       9057  4467
  one           606  1646
  zero          606   520
  ptrail        607
  pre_data_bits   16
  pre_data       0x40BE
  gap          108167
  toggle_bit_mask 0x0

      begin codes
          KEY_POWER                0x629D
          KEY_VOLUMEUP             0x30CF
          KEY_VOLUMEDOWN           0x9867
          KEY_CHANNELUP            0xF00F
          KEY_CHANNELDOWN          0x5AA5
          KEY_SWITCHVIDEOMODE      0xD22D
          KEY_ENTER                0x52AD
      end codes

end remote
```