### PR TITLE
Added TCL112AC A/C unit. 112 bits and bigger BUFFER

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -28,6 +28,10 @@
 // Each protocol you include costs memory and, during decode, costs time
 // Disable (set to 0) all the protocols you do not need/want!
 //
+
+#define DECODE_TCL112AC      1
+#define SEND_TCL112AC        1
+
 #define DECODE_RC5           1
 #define SEND_RC5             1
 
@@ -115,6 +119,7 @@ typedef
 		SHARP,
 		DENON,
 		PRONTO,
+		TCL112AC,
 	}
 decode_type_t;
 
@@ -181,6 +186,10 @@ class IRrecv
 		int   compare    (unsigned int oldval, unsigned int newval) ;
 
 		//......................................................................
+#   if (DECODE_TCL112AC)
+    bool   decodeTcl112ac (decode_results *results) ;
+#   endif
+    //......................................................................
 #		if (DECODE_RC5 || DECODE_RC6)
 			// This helper function is shared by RC5 and RC6
 			int  getRClevel (decode_results *results,  int *offset,  int *used,  int t1) ;
@@ -260,6 +269,10 @@ class IRsend
 		void  sendRaw     		(unsigned int buf[],  unsigned int len,  unsigned int hz) ;
 
 		//......................................................................
+#   if SEND_TCL112AC
+      void sendTcl112ac    (unsigned long data,  int nbits) ;
+#   endif
+    //......................................................................
 #		if SEND_RC5
 			void  sendRC5        (unsigned long data,  int nbits) ;
 #		endif

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -40,7 +40,7 @@
 //------------------------------------------------------------------------------
 // Information for the Interrupt Service Routine
 //
-#define RAWBUF  101  // Maximum length of raw duration buffer
+#define RAWBUF  229  // Maximum length of raw duration buffer
 
 typedef
 	struct {

--- a/irRecv.cpp
+++ b/irRecv.cpp
@@ -80,6 +80,11 @@ int  IRrecv::decode (decode_results *results)
 	if (decodeDenon(results))  return true ;
 #endif
 
+#if DECODE_TCL112AC
+  DBG_PRINTLN("Attempting Tcl112ac decode");
+	if (decodeTcl112ac(results))  return true ;
+#endif
+
 	// decodeHash returns a hash on any input.
 	// Thus, it needs to be last in the list.
 	// If you add any decodes, add them before this.
@@ -145,8 +150,8 @@ void  IRrecv::blink13 (int blinkflag)
 
 //+=============================================================================
 // Return if receiving new IR signals
-// 
-bool  IRrecv::isIdle ( ) 
+//
+bool  IRrecv::isIdle ( )
 {
  return (irparams.rcvstate == STATE_IDLE || irparams.rcvstate == STATE_STOP) ? true : false;
 }

--- a/ir_TCL112AC.cpp
+++ b/ir_TCL112AC.cpp
@@ -1,0 +1,93 @@
+/*
+Created by Gaspar de Elias for handling an A/C unit
+*/
+
+#include "IRremote.h"
+#include "IRremoteInt.h"
+
+//==============================================================================
+//
+//
+//                              TCL112AC
+//
+//
+//==============================================================================
+
+#define BITS          112  // The number of bits in the command
+
+#define HDR_MARK    3000  // The length of the Header:Mark
+#define HDR_SPACE   1650  // The lenght of the Header:Space
+
+#define BIT_MARK    525  // The length of a Bit:Mark
+#define ONE_SPACE   450  // The length of a Bit:Space for 1's
+#define ZERO_SPACE  1200  // The length of a Bit:Space for 0's
+
+#define OTHER       1234  // Other things you may need to define
+
+//+=============================================================================
+//
+#if SEND_TCL112AC
+void  IRsend::sendTcl112ac (unsigned long data,  int nbits)
+{
+	// Set IR carrier frequency
+	enableIROut(38);
+
+	// Header
+	mark (HDR_MARK);
+	space(HDR_SPACE);
+
+	// Data
+	for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+		if (data & mask) {
+			mark (BIT_MARK);
+			space(ONE_SPACE);
+		} else {
+			mark (BIT_MARK);
+			space(ZERO_SPACE);
+		}
+	}
+
+	// Footer
+	mark(BIT_MARK);
+    space(0);  // Always end with the LED off
+}
+#endif
+
+//+=============================================================================
+//
+#if DECODE_TCL112AC
+bool  IRrecv::decodeTcl112ac (decode_results *results)
+{
+	unsigned long  data   = 0;  // Somewhere to build our code
+	int            offset = 1;  // Skip the Gap reading
+
+	DBG_PRINTLN("Checking right amount of data: ");
+	DBG_PRINTLN(irparams.rawlen);
+
+	// Check we have the right amount of data
+	if (irparams.rawlen != 1 + 2 + (2 * BITS) + 1)  return false ;
+
+	// Check initial Mark+Space match
+	if (!MATCH_MARK (results->rawbuf[offset++], HDR_MARK ))  return false ;
+	if (!MATCH_SPACE(results->rawbuf[offset++], HDR_SPACE))  return false ;
+
+	// Read the bits in
+	for (int i = 0;  i < BITS;  i++) {
+		// Each bit looks like: MARK + SPACE_1 -> 1
+		//                 or : MARK + SPACE_0 -> 0
+		if (!MATCH_MARK(results->rawbuf[offset++], BIT_MARK))  return false ;
+
+		// IR data is big-endian, so we shuffle it in from the right:
+		if      (MATCH_SPACE(results->rawbuf[offset], ONE_SPACE))   data = (data << 1) | 1 ;
+		else if (MATCH_SPACE(results->rawbuf[offset], ZERO_SPACE))  data = (data << 1) | 0 ;
+		else                                                        return false ;
+		offset++;
+	}
+
+	// Success
+	results->bits        = BITS;
+	results->value       = data;
+	results->decode_type = TCL112AC;
+	return true;
+}
+#endif


### PR DESCRIPTION
This code works fine, but of course I have the following issues and I wouldn't like to merge until we define how to solve them.

Im creating this pull request just to show the reviewer the problems im facing:
1. Panasonic decode algorithm does not check the data length, and because this protocol is very similar (112 bits instead of max 48bits in panasonic), sometimes its cached as panasonic and truncated to 48bits. Should we add a size check in panasonic?
2. Raw buffer length is not enough to hold rawData[227]. Of course i don't want to change this for every user. What would you suggest?
