### PR TITLE
Added support for ATmega8535, ATmega16 and ATmega32

### DIFF
--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -189,6 +189,10 @@ EXTERN  volatile irparams_t  irparams;
 	//#define IR_USE_TIMER1   // tx = pin 13
 	#define IR_USE_TIMER2     // tx = pin 14
 
+// MightyCore - ATmega8535, ATmega16, ATmega32
+#elif defined(__AVR_ATmega8535__) || defined(__AVR_ATmega16__) || defined(__AVR_ATmega32__)
+	#define IR_USE_TIMER1     // tx = pin 13
+
 // Atmega8
 #elif defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
 	#define IR_USE_TIMER1     // tx = pin 9
@@ -271,7 +275,8 @@ EXTERN  volatile irparams_t  irparams;
 #define TIMER_DISABLE_PWM  (TCCR1A &= ~(_BV(COM1A1)))
 
 //-----------------
-#if defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
+#if defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__) || defined(__AVR_ATmega8535__) \
+ || defined(__AVR_ATmega16__) || defined(__AVR_ATmega32__)
 #	define TIMER_ENABLE_INTR   (TIMSK |= _BV(OCIE1A))
 #	define TIMER_DISABLE_INTR  (TIMSK &= ~_BV(OCIE1A))
 #else

--- a/README.md
+++ b/README.md
@@ -20,27 +20,29 @@ Check [here](http://z3t0.github.io/Arduino-IRremote/) for tutorials and more inf
 ## Supported Boards
 - Arduino Uno / Mega / Leonardo / Duemilanove / Diecimila / LilyPad / Mini / Fio / Nano etc.
 - Teensy 1.0 / 1.0++ / 2.0 / 2++ / 3.0 / 3.1 / Teensy-LC; Credits: @PaulStoffregen (Teensy Team)
-- Sanguino
+- ATmega8535 / ATmega16 / ATmega32 / ATmega164 / ATmega324 / ATmega644 / ATmega1284
 - Atmega8
-- ATtiny 84 / 85
+- ATtiny84 / ATtiny85
 
 We are open to suggestions for adding support to new boards, however we highly recommend you contact your supplier first and ask them to provide support from their side.
 
 ### Hardware specifications
 
-| Board/CPU                                | Send Pin            | Timers            |
-|------------------------------------------|---------------------|-------------------|
-| Arduino Mega / ATmega 1280 / ATmega 2560 | 5, 6, **9**, 11, 46 | 1, **2**, 3, 4, 5 |
-| Teensy 1.0                               | **17**              | **1**             |
-| Teensy 2.0                               | 9, **10**, 14       | 1, 3, **4_HS**    |
-| Teensy++ 1.0 / 2.0                       | **1**, 16, 25       | 1, **2**, 3       |
-| Teensy 3.0 / 3.1                         | **5**               | **CMT**           |
-| Teensy-LC                                | **16**              | **TPM1**          |
-| Sanguino                                 | 13, **14**          | 1, **2**          |
-| Atmega8                                  | **9**               | **1**             |
-| ATtiny84                                 | **6**               | **1**             |
-| ATtiny85                                 | **1**               | **TINY0**         |
-| Arduino Duemilanove, UNO etc.            | **3**, 9            | 1, **2**          |
+| Board/CPU                                                                | Send Pin            | Timers            |
+|--------------------------------------------------------------------------|---------------------|-------------------|
+| [ATtiny84](https://github.com/SpenceKonde/ATTinyCore)                 | **6**               | **1**             |
+| [ATtiny85](https://github.com/SpenceKonde/ATTinyCore)                 | **1**               | **TINY0**         |
+| ATmega8                                                                  | **9**               | **1**             |
+| ATmega168/328                                                            | **3**, 9            | 1, **2**          |
+| [ATmega8535/16/32](https://github.com/MCUdude/MightyCore)                | **13**              | **1**             |
+| [ATmega164/324/644/1284](https://github.com/MCUdude/MightyCore)          | 13, **14**          | 1, **2**          |
+| ATmega1280/2560                                                          | 5, 6, **9**, 11, 46 | 1, **2**, 3, 4, 5 |
+| [Teensy 1.0](https://www.pjrc.com/teensy/)                               | **17**              | **1**             |
+| [Teensy 2.0](https://www.pjrc.com/teensy/)                               | 9, **10**, 14       | 1, 3, **4_HS**    |
+| [Teensy++ 1.0 / 2.0](https://www.pjrc.com/teensy/)                       | **1**, 16, 25       | 1, **2**, 3       |
+| [Teensy 3.0 / 3.1](https://www.pjrc.com/teensy/)                         | **5**               | **CMT**           |
+| [Teensy-LC](https://www.pjrc.com/teensy/)                                | **16**              | **TPM1**          |
+
 
 The table above lists the currently supported timers and corresponding send pins, many of these can have additional pins opened up and we are open to requests if a need arises for other pins.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## 2.1.1 - 2016/03/23
+- Add support for ATmega8535, ATmega16 and ATmega32 [PR #293](https://github.com/z3t0/Arduino-IRremote/pull/293)
+
 ## 2.1.0 - 2016/02/20
 - Improved Debugging [PR #258](https://github.com/z3t0/Arduino-IRremote/pull/258)
 - Display TIME instead of TICKS [PR #258](https://github.com/z3t0/Arduino-IRremote/pull/258)


### PR DESCRIPTION
This pull request adds support for the ATmega8535, ATmega16 and ATmega32 using Timer 1 (tx = 13 with the standard pinout).