### PR TITLE
 Fixed bug in ir_Dish.cpp for sending

### DIFF
--- a/ir_Dish.cpp
+++ b/ir_Dish.cpp
@@ -48,6 +48,7 @@ void  IRsend::sendDISH (unsigned long data,  int nbits)
 			space(DISH_ZERO_SPACE);
 		}
 	}
+	mark(DISH_HDR_MARK); //added 26th March 2016, by AnalysIR ( https://www.AnalysIR.com )
 }
 #endif
 


### PR DESCRIPTION
One of our users of AnalysIR, reported issues with sending DIsh signals. After some investigation we realised that this file was neglecting to send the trailing mark after the bits. Fix is included in this update & has been tested on a live Dish device by our own user.

AnalysIR - 26th March 2016
----------------------------------------
https://www.AnalysIR.com/