### PR TITLE
distinguish SANGUINO from MICRODUINO Core+

### DIFF
--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -184,10 +184,10 @@ EXTERN  volatile irparams_t  irparams;
 	#define IR_USE_TIMER2     // tx = pin 1
 	//#define IR_USE_TIMER3   // tx = pin 16
 
-// Sanguino
+// Sanguino  or Microduino
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
 	//#define IR_USE_TIMER1   // tx = pin 13
-	#define IR_USE_TIMER2     // tx = pin 14
+	#define IR_USE_TIMER2     // tx = pin 14 for sanguino and 8 for microduino
 
 // Atmega8
 #elif defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
@@ -256,7 +256,11 @@ EXTERN  volatile irparams_t  irparams;
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  9              // Arduino Mega
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-#	define TIMER_PWM_PIN  14             // Sanguino
+	#if defined(MICRODUINO)
+		#define TIMER_PWM_PIN  8             // microduino pd6
+	#else 	#define TIMER_PWM_PIN  14             // sanguino pd6
+	#endif
+
 #else
 #	define TIMER_PWM_PIN  3              // Arduino Duemilanove, Diecimila, LilyPad, etc
 #endif
@@ -302,8 +306,11 @@ EXTERN  volatile irparams_t  irparams;
 #	define TIMER_PWM_PIN  CORE_OC1A_PIN  // Teensy
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  11             // Arduino Mega
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-#	define TIMER_PWM_PIN  13             // Sanguino
+#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)// Sanguino or microduino
+	#if defined(MICRODUINO)
+		#define TIMER_PWM_PIN  9        // microduino PD5
+	#else   #define TIMER_PWM_PIN  13        //sanguino PD5
+	#endif
 #elif defined(__AVR_ATtiny84__)
 # define TIMER_PWM_PIN  6
 #else

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -18,10 +18,6 @@
 #define IRremoteint_h
 
 
-// If you are using sanguino comment the line below
-// #define if you are using Microduino 
-#define MICRODUINO   
-
 //------------------------------------------------------------------------------
 // Include the right Arduino header
 //
@@ -261,7 +257,8 @@ EXTERN  volatile irparams_t  irparams;
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  9              // Arduino Mega
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-	#if defined(MICRODUINO)
+//Core+ defines NUM_DIGITAL_PINS as 32, whereas Sanguino defines it as 24.
+	#if defined(NUM_DIGITAL_PINS == 32)
 		#define TIMER_PWM_PIN  8             // microduino pd6
 	#else 	
 		#define TIMER_PWM_PIN  14             // sanguino pd6
@@ -313,7 +310,8 @@ EXTERN  volatile irparams_t  irparams;
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  11             // Arduino Mega
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)// Sanguino or microduino
-	#if defined(MICRODUINO)
+//Core+ defines NUM_DIGITAL_PINS as 32, whereas Sanguino defines it as 24.
+	#if defined(NUM_DIGITAL_PINS == 32)
 		#define TIMER_PWM_PIN  9        // microduino PD5
 	#else   #define TIMER_PWM_PIN  13        //sanguino PD5
 	#endif

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -17,6 +17,11 @@
 #ifndef IRremoteint_h
 #define IRremoteint_h
 
+
+// If you are using sanguino comment the line below
+// #define if you are using Microduino 
+#define MICRODUINO   
+
 //------------------------------------------------------------------------------
 // Include the right Arduino header
 //
@@ -258,7 +263,8 @@ EXTERN  volatile irparams_t  irparams;
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
 	#if defined(MICRODUINO)
 		#define TIMER_PWM_PIN  8             // microduino pd6
-	#else 	#define TIMER_PWM_PIN  14             // sanguino pd6
+	#else 	
+		#define TIMER_PWM_PIN  14             // sanguino pd6
 	#endif
 
 #else

--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Check [here](http://z3t0.github.io/Arduino-IRremote/) for tutorials and more inf
 
 ## Version - 2.1.0
 
+## Hardware setup
+The library can use any of the digital input signals to receive the input from a 38KHz IR receiver module. It has been tested with the Radio Shack 276-640 IR receiver and the Panasonic PNA4602. Simply wire power to pin 1, ground to pin 2, and the pin 3 output to an Arduino digital input pin, e.g. 11. These receivers provide a filtered and demodulated inverted logic level output; you can't just use a photodiode or phototransistor. I have found these detectors have pretty good range and easily work across a room.
+IR wiring
+
+![alt tag](http://arcfn.com/images/ir-schematic.png)
+
+
+For output, connect an IR LED and appropriate resistor to PWM output pin 3. Make sure the polarity of the LED is correct, or it won't illuminate - the long lead is positive. I used a NTE 3027 LED (because that's what was handy) and 100 ohm resistor; the range is about 15 feet. For additional range, you can amplify the output with a transistor.
+
+
 ## Installation
 1. Navigate to the [Releases](https://github.com/z3t0/Arduino-IRremote/releases) page.
 2. Download the latest release.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@ Check [here](http://z3t0.github.io/Arduino-IRremote/) for tutorials and more inf
 ## Version - 2.1.0
 
 ## Hardware setup
-The library can use any of the digital input signals to receive the input from a 38KHz IR receiver module. It has been tested with the Radio Shack 276-640 IR receiver and the Panasonic PNA4602. Simply wire power to pin 1, ground to pin 2, and the pin 3 output to an Arduino digital input pin, e.g. 11. These receivers provide a filtered and demodulated inverted logic level output; you can't just use a photodiode or phototransistor. I have found these detectors have pretty good range and easily work across a room.
+The library can use any of the digital input signals to receive the input from a 38KHz IR receiver module. It has been tested with the Radio Shack [276-640](http://www.radioshack.com/product/index.jsp?productId=2049727) IR receiver and the Panasonic [PNA4602](http://www.adafruit.com/index.php?main_page=product_info&cPath=35&products_id=157). Simply wire power to pin 1, ground to pin 2, and the pin 3 output to an Arduino digital input pin, e.g. 11. These receivers provide a filtered and demodulated inverted logic level output; you can't just use a photodiode or phototransistor. I have found these detectors have pretty good range and easily work across a room.
 IR wiring
 
 ![alt tag](http://arcfn.com/images/ir-schematic.png)
 
 
 For output, connect an IR LED and appropriate resistor to PWM output pin 3. Make sure the polarity of the LED is correct, or it won't illuminate - the long lead is positive. I used a NTE 3027 LED (because that's what was handy) and 100 ohm resistor; the range is about 15 feet. For additional range, you can amplify the output with a transistor.
-
+[source](http://www.righto.com/2009/08/multi-protocol-infrared-remote-library.html)
 
 ## Installation
 1. Navigate to the [Releases](https://github.com/z3t0/Arduino-IRremote/releases) page.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Check [here](http://z3t0.github.io/Arduino-IRremote/) for tutorials and more inf
 - Arduino Uno / Mega / Leonardo / Duemilanove / Diecimila / LilyPad / Mini / Fio / Nano etc.
 - Teensy 1.0 / 1.0++ / 2.0 / 2++ / 3.0 / 3.1 / Teensy-LC; Credits: @PaulStoffregen (Teensy Team)
 - Sanguino
+- microduino core+
 - Atmega8
 - ATtiny 84 / 85
 
@@ -36,7 +37,8 @@ We are open to suggestions for adding support to new boards, however we highly r
 | Teensy++ 1.0 / 2.0                       | **1**, 16, 25       | 1, **2**, 3       |
 | Teensy 3.0 / 3.1                         | **5**               | **CMT**           |
 | Teensy-LC                                | **16**              | **TPM1**          |
-| Sanguino                                 | 13, **14**          | 1, **2**          |
+| Sanguino								   | 13, **14**          | 1, **2**          |
+| microduino core +                        | 9, **8**            | 1, **2**          |
 | Atmega8                                  | **9**               | **1**             |
 | ATtiny84                                 | **6**               | **1**             |
 | ATtiny85                                 | **1**               | **TINY0**         |

--- a/examples/IRremoteInfo/IRremoteInfo.ino
+++ b/examples/IRremoteInfo/IRremoteInfo.ino
@@ -108,7 +108,7 @@ void dumpPlatform() {
 #elif defined(__AVR_AT90USB1286__)
   Serial.println(F("Teensy++ 2.0 / AT90USB1286"));
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-  #if defined(MICRODUINO)
+  #if defined(NUM_DIGITAL_PINS == 32)  //For Micoduino
     Serial.println(F("Microduino core + / ATmega644(P)"));
   #else     
     Serial.println(F("Sanguino / ATmega644(P)"));

--- a/examples/IRremoteInfo/IRremoteInfo.ino
+++ b/examples/IRremoteInfo/IRremoteInfo.ino
@@ -108,7 +108,11 @@ void dumpPlatform() {
 #elif defined(__AVR_AT90USB1286__)
   Serial.println(F("Teensy++ 2.0 / AT90USB1286"));
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-  Serial.println(F("Sanguino / ATmega644(P)"));
+  #if defined(MICRODUINO)
+    Serial.println(F("Microduino core + / ATmega644(P)"));
+  #else     
+    Serial.println(F("Sanguino / ATmega644(P)"));
+  #endif
 #elif defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
   Serial.println(F("Atmega8 / ATmega8(P)"));
 #elif defined(__AVR_ATtiny84__)


### PR DESCRIPTION
SANGUINO and MICRODUINO both use Atmega_644PA although they have completely different pin mappings. 

PD6 is  PIN 14  on sanguino, while on Microduino it is PIN 8
