### PR TITLE
Send Codes by direct wiring (without IR-LED)

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -95,6 +95,15 @@
 #define PRONTO_NOFALLBACK  false
 
 //------------------------------------------------------------------------------
+// When set to 1, you can wiring directly to your target device, without
+// to use an IR-LED and IR-receiver.
+// All codes will be send without a carrier and digital.
+// NOTE: If you have a 5V Arduino board you should use a resitor divider to do
+// not damage your target device input pin, you have directly wired.
+//
+#define SEND_BY_DIRECT_WIRING	0
+
+//------------------------------------------------------------------------------
 // An enumerated list of all supported formats
 // You do NOT need to remove entries from this list when disabling protocols!
 //

--- a/irSend.cpp
+++ b/irSend.cpp
@@ -21,7 +21,11 @@ void  IRsend::sendRaw (const unsigned int buf[],  unsigned int len,  unsigned in
 //
 void  IRsend::mark (unsigned int time)
 {
+#if SEND_BY_DIRECT_WIRING
+	digitalWrite(TIMER_PWM_PIN, LOW);
+#else
 	TIMER_ENABLE_PWM; // Enable pin 3 PWM output
+#endif
 	if (time > 0) custom_delay_usec(time);
 }
 
@@ -32,7 +36,11 @@ void  IRsend::mark (unsigned int time)
 //
 void  IRsend::space (unsigned int time)
 {
+#if SEND_BY_DIRECT_WIRING
+	digitalWrite(TIMER_PWM_PIN, HIGH);
+#else
 	TIMER_DISABLE_PWM; // Disable pin 3 PWM output
+#endif
 	if (time > 0) IRsend::custom_delay_usec(time);
 }
 
@@ -58,6 +66,10 @@ void  IRsend::enableIROut (int khz)
 	TIMER_DISABLE_INTR; //Timer2 Overflow Interrupt
 
 	pinMode(TIMER_PWM_PIN, OUTPUT);
+#if SEND_BY_DIRECT_WIRING
+	khz = khz; // avoid compiler warning: unused parameter ‘khz’
+	digitalWrite(TIMER_PWM_PIN, HIGH);
+#else
 	digitalWrite(TIMER_PWM_PIN, LOW); // When not sending PWM, we want it low
 
 	// COM2A = 00: disconnect OC2A
@@ -66,6 +78,7 @@ void  IRsend::enableIROut (int khz)
 	// CS2  = 000: no prescaling
 	// The top value for the timer.  The modulation frequency will be SYSCLOCK / 2 / OCR2A.
 	TIMER_CONFIG_KHZ(khz);
+#endif
 }
 
 //+=============================================================================
@@ -79,7 +92,7 @@ void IRsend::custom_delay_usec(unsigned long uSecs) {
       while ( micros() > start ) {} // wait until overflow
     }
     while ( micros() < endMicros ) {} // normal wait
-  } 
+  }
   //else {
   //  __asm__("nop\n\t"); // must have or compiler optimizes out
   //}


### PR DESCRIPTION
With these changes in this PR, I can send codes from my Arduino Nano to my Raspberry running lirc and the lirc-rpi overlay, without to use a IR-LED (Arduino) and IR-receiver (Raspberry).
When `SEND_BY_DIRECT_WIRING` is set to `1` in the header IRremote.h, the `TIMER_PWM_PIN` will be used to send digital codes and not pwm.

Please have look, it is working for me
