### PR TITLE
Add support for ATmega8535, ATmega16, ATmega32, ATmega164, ATmega324, ATmega644, ATmega1284 and ATmega64, ATmega128

### DIFF
--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -184,13 +184,31 @@ EXTERN  volatile irparams_t  irparams;
 	#define IR_USE_TIMER2     // tx = pin 1
 	//#define IR_USE_TIMER3   // tx = pin 16
 
-// Sanguino
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
+// MightyCore - ATmega1284
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
 	//#define IR_USE_TIMER1   // tx = pin 13
 	#define IR_USE_TIMER2     // tx = pin 14
+	//#define IR_USE_TIMER3   // tx = pin 6
+
+// MightyCore - ATmega164, ATmega324, ATmega644
+#elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) \
+|| defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324A__) \
+|| defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega164A__) \
+|| defined(__AVR_ATmega164P__)
+	//#define IR_USE_TIMER1   // tx = pin 13
+	#define IR_USE_TIMER2     // tx = pin 14
+	
+//MegaCore - ATmega64, ATmega128
+#elif defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
+ 	#define IR_USE_TIMER1     // tx = pin 13
+
+// MightyCore - ATmega8535, ATmega16, ATmega32
+#elif defined(__AVR_ATmega8535__) || defined(__AVR_ATmega16__) || defined(__AVR_ATmega32__)
+ 	#define IR_USE_TIMER1     // tx = pin 13
+ 
 
 // Atmega8
-#elif defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
+#elif defined(__AVR_ATmega8__)
 	#define IR_USE_TIMER1     // tx = pin 9
 
 // ATtiny84
@@ -255,8 +273,12 @@ EXTERN  volatile irparams_t  irparams;
 #	define TIMER_PWM_PIN  CORE_OC2B_PIN  // Teensy
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  9              // Arduino Mega
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-#	define TIMER_PWM_PIN  14             // Sanguino
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) \
+|| defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) \
+|| defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324A__) \
+|| defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega164A__) \
+|| defined(__AVR_ATmega164P__)
+#	define TIMER_PWM_PIN  14             // MightyCore
 #else
 #	define TIMER_PWM_PIN  3              // Arduino Duemilanove, Diecimila, LilyPad, etc
 #endif
@@ -271,7 +293,9 @@ EXTERN  volatile irparams_t  irparams;
 #define TIMER_DISABLE_PWM  (TCCR1A &= ~(_BV(COM1A1)))
 
 //-----------------
-#if defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
+#if defined(__AVR_ATmega8__) || defined(__AVR_ATmega8535__) \
+|| defined(__AVR_ATmega16__) || defined(__AVR_ATmega32__) \
+|| defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
 #	define TIMER_ENABLE_INTR   (TIMSK |= _BV(OCIE1A))
 #	define TIMER_DISABLE_INTR  (TIMSK &= ~_BV(OCIE1A))
 #else
@@ -302,10 +326,17 @@ EXTERN  volatile irparams_t  irparams;
 #	define TIMER_PWM_PIN  CORE_OC1A_PIN  // Teensy
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  11             // Arduino Mega
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-#	define TIMER_PWM_PIN  13             // Sanguino
+#elif defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
+#	define TIMER_PWM_PIN  13	     // MegaCore
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) \
+|| defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) \
+|| defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324A__) \
+|| defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega164A__) \
+|| defined(__AVR_ATmega164P__) || defined(__AVR_ATmega32__) \
+|| defined(__AVR_ATmega16__) || defined(__AVR_ATmega8535__)
+#	define TIMER_PWM_PIN  13             // MightyCore
 #elif defined(__AVR_ATtiny84__)
-# define TIMER_PWM_PIN  6
+# 	define TIMER_PWM_PIN  6
 #else
 #	define TIMER_PWM_PIN  9              // Arduino Duemilanove, Diecimila, LilyPad, etc
 #endif
@@ -342,6 +373,8 @@ EXTERN  volatile irparams_t  irparams;
 #	define TIMER_PWM_PIN  CORE_OC3A_PIN  // Teensy
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  5              // Arduino Mega
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
+#	define TIMER_PWM_PIN  6              // MightyCore
 #else
 #	error "Please add OC3A pin number here\n"
 #endif

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -205,7 +205,6 @@ EXTERN  volatile irparams_t  irparams;
 // MightyCore - ATmega8535, ATmega16, ATmega32
 #elif defined(__AVR_ATmega8535__) || defined(__AVR_ATmega16__) || defined(__AVR_ATmega32__)
  	#define IR_USE_TIMER1     // tx = pin 13
- 
 
 // Atmega8
 #elif defined(__AVR_ATmega8__)

--- a/README.md
+++ b/README.md
@@ -28,19 +28,22 @@ We are open to suggestions for adding support to new boards, however we highly r
 
 ### Hardware specifications
 
-| Board/CPU                                | Send Pin            | Timers            |
-|------------------------------------------|---------------------|-------------------|
-| Arduino Mega / ATmega 1280 / ATmega 2560 | 5, 6, **9**, 11, 46 | 1, **2**, 3, 4, 5 |
-| Teensy 1.0                               | **17**              | **1**             |
-| Teensy 2.0                               | 9, **10**, 14       | 1, 3, **4_HS**    |
-| Teensy++ 1.0 / 2.0                       | **1**, 16, 25       | 1, **2**, 3       |
-| Teensy 3.0 / 3.1                         | **5**               | **CMT**           |
-| Teensy-LC                                | **16**              | **TPM1**          |
-| Sanguino                                 | 13, **14**          | 1, **2**          |
-| Atmega8                                  | **9**               | **1**             |
-| ATtiny84                                 | **6**               | **1**             |
-| ATtiny85                                 | **1**               | **TINY0**         |
-| Arduino Duemilanove, UNO etc.            | **3**, 9            | 1, **2**          |
+| Board/CPU                                                                | Send Pin            | Timers            |
+|--------------------------------------------------------------------------|---------------------|-------------------|
+| [ATtiny84](https://github.com/SpenceKonde/ATTinyCore)                    | **6**               | **1**             |
+| [ATtiny85](https://github.com/SpenceKonde/ATTinyCore)                    | **1**               | **TINY0**         |
+| ATmega8                                                                  | **9**               | **1**             |
+| ATmega168, ATmega328                                                     | **3**, 9            | 1, **2**          |
+| [ATmega1284](https://github.com/MCUdude/MightyCore)                      | 13, 14, 6           | 1, **2**, 3       |
+| [ATmega164, ATmega324, ATmega644](https://github.com/MCUdude/MightyCore) | 13, **14**          | 1, **2**          |
+| [ATmega8535 ATmega16, ATmega32](https://github.com/MCUdude/MightyCore)   | **13**              | **1**             |
+| [ATmega64, ATmega128](https://github.com/MCUdude/MegaCore)               | **13**              | **1**             |
+| ATmega1280, ATmega2560                                                   | 5, 6, **9**, 11, 46 | 1, **2**, 3, 4, 5 |
+| [Teensy 1.0](https://www.pjrc.com/teensy/)                               | **17**              | **1**             |
+| [Teensy 2.0](https://www.pjrc.com/teensy/)                               | 9, **10**, 14       | 1, 3, **4_HS**    |
+| [Teensy++ 1.0 / 2.0](https://www.pjrc.com/teensy/)                       | **1**, 16, 25       | 1, **2**, 3       |
+| [Teensy 3.0 / 3.1](https://www.pjrc.com/teensy/)                         | **5**               | **CMT**           |
+| [Teensy-LC](https://www.pjrc.com/teensy/)                                | **16**              | **TPM1**          |
 
 The table above lists the currently supported timers and corresponding send pins, many of these can have additional pins opened up and we are open to requests if a need arises for other pins.
 

--- a/examples/IRremoteInfo/IRremoteInfo.ino
+++ b/examples/IRremoteInfo/IRremoteInfo.ino
@@ -107,8 +107,24 @@ void dumpPlatform() {
   Serial.println(F("Teensy++ 1.0 / AT90USB646"));
 #elif defined(__AVR_AT90USB1286__)
   Serial.println(F("Teensy++ 2.0 / AT90USB1286"));
-#elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
-  Serial.println(F("Sanguino / ATmega644(P)"));
+#elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
+  Serial.println(F("ATmega1284"));
+#elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__)
+  Serial.println(F("ATmega644"));
+#elif defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324A__) || defined(__AVR_ATmega324PA__)
+  Serial.println(F("ATmega324")); 
+#elif defined(__AVR_ATmega164A__) || defined(__AVR_ATmega164P__)
+  Serial.println(F("ATmega164"));
+#elif defined(__AVR_ATmega128__)
+  Serial.println(F("ATmega128"));
+#elif defined(__AVR_ATmega64__)
+  Serial.println(F("ATmega64"));
+#elif defined(__AVR_ATmega32__)
+  Serial.println(F("ATmega32"));  
+#elif defined(__AVR_ATmega16__)
+  Serial.println(F("ATmega16"));
+#elif defined(__AVR_ATmega8535__)
+  Serial.println(F("ATmega8535"));  
 #elif defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
   Serial.println(F("Atmega8 / ATmega8(P)"));
 #elif defined(__AVR_ATtiny84__)

--- a/examples/IRremoteInfo/IRremoteInfo.ino
+++ b/examples/IRremoteInfo/IRremoteInfo.ino
@@ -125,8 +125,8 @@ void dumpPlatform() {
   Serial.println(F("ATmega16"));
 #elif defined(__AVR_ATmega8535__)
   Serial.println(F("ATmega8535"));  
-#elif defined(__AVR_ATmega8P__) || defined(__AVR_ATmega8__)
-  Serial.println(F("Atmega8 / ATmega8(P)"));
+#elif defined(__AVR_ATmega8__)
+  Serial.println(F("Atmega8"));
 #elif defined(__AVR_ATtiny84__)
   Serial.println(F("ATtiny84"));
 #elif defined(__AVR_ATtiny85__)


### PR DESCRIPTION
I wasn't able to update my fork when it was out of sync with yours, but I created a new pull request instead. I've tested these microcontrollers, and the work just fine with their corresponding timer pins. Please merge this pull request. I didn't do any changes to the changelog, so you can handle the versions 😉 