### PR TITLE
Add ATmega48 and ATmega88 to the list (+ some other minor commits)

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -16,5 +16,6 @@ These are the active contributors of this project that you may contact if there 
 - [lumbric](https://github.com/lumbric): Contributor
 - [ElectricRCAircraftGuy](https://github.com/electricrcaircraftguy): Active Contributor
 - [henkel](https://github.com/henkel): Contributor
+- [MCUdude](https://github.com/MCUdude): Contributor
 
 Note: This list is being updated constantly so please let [z3t0](https://github.com/z3t0) know if you have been missed.

--- a/IRremoteInt.h
+++ b/IRremoteInt.h
@@ -219,6 +219,7 @@ EXTERN  volatile irparams_t  irparams;
   #define IR_USE_TIMER_TINY0   // tx = pin 1
 
 // Arduino Duemilanove, Diecimila, LilyPad, Mini, Fio, Nano, etc
+// ATmega48, ATmega88, ATmega168, ATmega328
 #else
 	//#define IR_USE_TIMER1   // tx = pin 9
 	#define IR_USE_TIMER2     // tx = pin 3
@@ -280,7 +281,7 @@ EXTERN  volatile irparams_t  irparams;
 #	define TIMER_PWM_PIN  14             // MightyCore
 #else
 #	define TIMER_PWM_PIN  3              // Arduino Duemilanove, Diecimila, LilyPad, etc
-#endif
+#endif					     // ATmega48, ATmega88, ATmega168, ATmega328
 
 //---------------------------------------------------------
 // Timer1 (16 bits)
@@ -338,7 +339,7 @@ EXTERN  volatile irparams_t  irparams;
 # 	define TIMER_PWM_PIN  6
 #else
 #	define TIMER_PWM_PIN  9              // Arduino Duemilanove, Diecimila, LilyPad, etc
-#endif
+#endif					     // ATmega48, ATmega88, ATmega168, ATmega328
 
 //---------------------------------------------------------
 // Timer3 (16 bits)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Check [here](http://z3t0.github.io/Arduino-IRremote/) for tutorials and more inf
 - Arduino Uno / Mega / Leonardo / Duemilanove / Diecimila / LilyPad / Mini / Fio / Nano etc.
 - Teensy 1.0 / 1.0++ / 2.0 / 2++ / 3.0 / 3.1 / Teensy-LC; Credits: @PaulStoffregen (Teensy Team)
 - Sanguino
-- Atmega8535, 8, 16, 32, 164, 324, 644, 1284, 64, 128
+- ATmega8, 48, 88, 168, 328
+- ATmega8535, 16, 32, 164, 324, 644, 1284,
+- ATmega64, 128
 - ATtiny 84 / 85
 
 We are open to suggestions for adding support to new boards, however we highly recommend you contact your supplier first and ask them to provide support from their side.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ We are open to suggestions for adding support to new boards, however we highly r
 |--------------------------------------------------------------------------|---------------------|-------------------|
 | [ATtiny84](https://github.com/SpenceKonde/ATTinyCore)                    | **6**               | **1**             |
 | [ATtiny85](https://github.com/SpenceKonde/ATTinyCore)                    | **1**               | **TINY0**         |
-| ATmega8                                                                  | **9**               | **1**             |
+| [ATmega8](https://github.com/MCUdude/MiniCore)                           | **9**               | **1**             |
 | Atmega32u4                                                               | 5, 9, **13**        | 1, 3, **4**       |
-| ATmega168, ATmega328                                                     | **3**, 9            | 1, **2**          |
+| [ATmega48, ATmega88, ATmega168, ATmega328](https://github.com/MCUdude/MiniCore) | **3**, 9     | 1, **2**          |
 | [ATmega1284](https://github.com/MCUdude/MightyCore)                      | 13, 14, 6           | 1, **2**, 3       |
 | [ATmega164, ATmega324, ATmega644](https://github.com/MCUdude/MightyCore) | 13, **14**          | 1, **2**          |
 | [ATmega8535 ATmega16, ATmega32](https://github.com/MCUdude/MightyCore)   | **13**              | **1**             |

--- a/examples/IRremoteInfo/IRremoteInfo.ino
+++ b/examples/IRremoteInfo/IRremoteInfo.ino
@@ -117,8 +117,12 @@ void dumpPlatform() {
   Serial.println(F("ATmega164"));
 #elif defined(__AVR_ATmega128__)
   Serial.println(F("ATmega128"));
+#elif defined(__AVR_ATmega88__) || defined(__AVR_ATmega88P__)
+  Serial.println(F("ATmega88"));  
 #elif defined(__AVR_ATmega64__)
   Serial.println(F("ATmega64"));
+#elif defined(__AVR_ATmega48__) || defined(__AVR_ATmega48P__)
+  Serial.println(F("ATmega48"));
 #elif defined(__AVR_ATmega32__)
   Serial.println(F("ATmega32"));  
 #elif defined(__AVR_ATmega16__)


### PR DESCRIPTION
I've just created an Arduino core for the ATmega8, ATmega48, ATmega88, ATmega168 and ATmega328, But the ATmega48/88 are missing on the list. How about adding these? 😃 