### PR TITLE
Misleading link to "tutorials and more information"

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This library enables you to send and receive using infra-red signals on an Arduino.
 
-Check [here](http://z3t0.github.io/Arduino-IRremote/) for tutorials and more information.
+Tutorials and more information will be made available on [the official homepage](http://z3t0.github.io/Arduino-IRremote/).
 
 ## Version - 2.2.0
 


### PR DESCRIPTION
The link points to the homepage, which is identical to the README at
the moment, and (to the best of my knowledge) does not yet cover
tutorials.  I propose to rephrase the sentence.