### PR TITLE
Added support for sending RC5x commands

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -31,6 +31,8 @@
 #define DECODE_RC5           1
 #define SEND_RC5             1
 
+#define SEND_RC5X            1
+
 #define DECODE_RC6           1
 #define SEND_RC6             1
 
@@ -270,6 +272,9 @@ class IRsend
 		//......................................................................
 #		if SEND_RC5
 			void  sendRC5        (unsigned long data,  int nbits) ;
+#		endif
+#		if SEND_RC5X
+			void  sendRC5x       (unsigned char toggle,  unsigned char system,  unsigned char command,  unsigned char extension) ;
 #		endif
 #		if SEND_RC6
 			void  sendRC6        (unsigned long data,  int nbits) ;

--- a/ir_RC5_RC6.cpp
+++ b/ir_RC5_RC6.cpp
@@ -114,6 +114,53 @@ bool  IRrecv::decodeRC5 (decode_results *results)
 #endif
 
 //+=============================================================================
+#if SEND_RC5X
+// send RC5x command defined by system, command and extension
+void IRsend::sendRC5x(unsigned char toggle, unsigned char system, unsigned char command, unsigned char extension){
+	
+	unsigned long data;
+	// if command is greater than 63, the second bit will be zero
+	if (command & 64){
+		data = 2;
+	}else{
+		data = 3;
+	}
+		
+	
+	// copy lsb of toggle into data
+	data = (data<<1) | (toggle & 1);
+	// copy lower 5 bits of system into data
+	data = (data<<5) | (system & 0x1F);
+	// shift by command length (6 bits) and add command
+	data = (data<<6) | (command & 0x3F);
+	// shift by extension length and add extension
+	data = (data<<6) | (extension & 0x3F);
+	
+	// the full command is 20 bits long
+	enableIROut(36);
+	data = data << 12;
+	
+	// the initializing bits are included in the data
+	for (int i = 0; i < 20; i++) {
+		if (data & TOPBIT) {
+			space(RC5_T1); // 1 is space, then mark
+			mark(RC5_T1);
+		} else {
+			mark(RC5_T1);
+			space(RC5_T1);
+		}
+		data <<= 1;
+		// we use the RC5x protocol, which includes 2
+		// low cycles (4 spaces) after the device id
+		if (i==7){
+			space(4*RC5_T1);
+		}
+	}
+	space(0); // Turn off at end
+}
+#endif
+
+//+=============================================================================
 // RRRR    CCCC   6666
 // R   R  C      6
 // RRRR   C      6666


### PR DESCRIPTION
RC5x commands have a 2-cycle pause after the device ID, so they can't be
sent with the regular RC5 protocol.

This commit adds an sendRC5x function that accepts device ID, command and extension and sends the appropriate IR signal.

I have tested this with the modified IRRemote library for the ESP8266 and a Marantz amplifier.

This commit doesn't support decoding for RC5x because I don't have the means to test this.

See discussion at https://github.com/z3t0/Arduino-IRremote/issues/14