### PR TITLE
Pioneer send support

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -79,6 +79,8 @@
 #define DECODE_LEGO_PF       0 // NOT WRITTEN
 #define SEND_LEGO_PF         1
 
+#define DECODE_PIONEER       0 // NOT WRITTEN
+#define SEND_PIONEER         1
 //------------------------------------------------------------------------------
 // When sending a Pronto code we request to send either the "once" code
 //                                                   or the "repeat" code
@@ -119,6 +121,7 @@ typedef
 		DENON,
 		PRONTO,
 		LEGO_PF,
+		PIONEER,
 	}
 decode_type_t;
 
@@ -247,9 +250,13 @@ class IRrecv
 #		if DECODE_DENON
 			bool  decodeDenon (decode_results *results) ;
 #		endif
-//......................................................................
+		//......................................................................
 #		if DECODE_LEGO_PF
 			bool  decodeLegoPowerFunctions (decode_results *results) ;
+#		endif
+		//......................................................................
+#		if DECODE_PIONEER
+          		bool  decodePioneer (decode_results *results) ; //NOT WRITTEN
 #		endif
 } ;
 
@@ -335,9 +342,13 @@ class IRsend
 #		if SEND_PRONTO
 			void  sendPronto     (char* code,  bool repeat,  bool fallback) ;
 #		endif
-//......................................................................
+		//......................................................................
 #		if SEND_LEGO_PF
 			void  sendLegoPowerFunctions (uint16_t data, bool repeat = true) ;
+#		endif
+		//......................................................................
+#		if SEND_PIONEER
+          		void  sendPioneer (unsigned int devicecode,  unsigned long data);
 #		endif
 } ;
 

--- a/ir_Pioneer.cpp
+++ b/ir_Pioneer.cpp
@@ -1,0 +1,66 @@
+#include "IRremote.h"
+#include "IRremoteInt.h"
+
+//==============================================================================
+//
+//
+//                              P I O N E E R
+//
+//
+//==============================================================================
+// Device Code in Hex Format
+// e.g. 165 for AVR Receiver
+
+#define PIONEER_BITS          32  // The number of bits in the command
+
+#define PIONEER_HDR_MARK    9000  // The length of the Header:Mark
+#define PIONEER_HDR_SPACE   4500  // The lenght of the Header:Space
+
+#define PIONEER_BIT_MARK    550  // The length of a Bit:Mark
+#define PIONEER_ONE_SPACE   1675  // The length of a Bit:Space for 1's
+#define PIONEER_ZERO_SPACE  550  // The length of a Bit:Space for 0's
+
+//+=============================================================================
+//
+#if SEND_PIONEER
+void  IRsend::sendPioneer (unsigned int devicecode,  unsigned long data)
+{
+	// Set IR carrier frequency
+	enableIROut(39.2);
+
+	// Header
+	mark (PIONEER_HDR_MARK);
+	space(PIONEER_HDR_SPACE);
+
+	// Device Code
+	for (unsigned long  mask = 1UL << (8 - 1);  mask;  mask >>= 1) {
+		mark(PIONEER_BIT_MARK);
+		if (devicecode & mask)  space(PIONEER_ONE_SPACE) ;
+		else                 space(PIONEER_ZERO_SPACE) ;
+    }
+    // Inverted Device Code
+	for (unsigned long  mask = 1UL << (8 - 1);  mask;  mask >>= 1) {
+		mark(PIONEER_BIT_MARK);
+		if (devicecode & mask)  space(PIONEER_ZERO_SPACE) ;
+		else                 space(PIONEER_ONE_SPACE) ;
+    }
+	// Data
+	for (unsigned long  mask = 1UL << (8 - 1);  mask;  mask >>= 1) {
+        mark(PIONEER_BIT_MARK);
+        if (data & mask)  space(PIONEER_ONE_SPACE) ;
+        else              space(PIONEER_ZERO_SPACE) ;
+    }
+
+    // Inverted Data
+    for (unsigned long  mask = 1UL << (8 - 1);  mask;  mask >>= 1) {
+	    mark(PIONEER_BIT_MARK);
+	    if (data & mask)  space(PIONEER_ZERO_SPACE) ;
+	    else              space(PIONEER_ONE_SPACE) ;
+    }
+
+	// Footer
+	mark(PIONEER_BIT_MARK);
+    space(0);  // Always end with the LED off
+}
+#endif
+


### PR DESCRIPTION
Adds send function for pioneer devices
Pioneer uses basically a NEC format

unfortunately none of the IR Codes from the official Pioneer Website worked for me. I have no IR receiver so i had to learn it the hard way and read a lot about the pioneer code on the internet. I decoded the signal: Start - 8 bit Device Code - 8 bit Device Code inverted - 8 bit Function Code - 8 bit Function Code inverted - End

Frequency: 39.2 kHz works fine for me.

Luckily i found a signal which worked for me:
As in every source, my AV Receiver (VSX-S300) has the Device Code 165. With that i tried every of the 256 function codes. Sadly they had no structure, (e.g. Power) and no linked connection to any of the OBCs on the internet.

Hope this helps anybode.

the structure of the send Function is (8bit Device Code, 8bit Function code), so that you need a minimum amount of memory to store a lot of different codes. Keep in mind: My AVR wants to have each signal sent three times (a delay of 30 works fine for me)