### PR TITLE
Added ESP32 IR receive support (IRsend not implemented yet).

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -18,5 +18,6 @@ These are the active contributors of this project that you may contact if there 
 - [ElectricRCAircraftGuy](https://github.com/electricrcaircraftguy): Active Contributor
 - [philipphenkel](https://github.com/philipphenkel): Active Contributor
 - [MCUdude](https://github.com/MCUdude): Contributor
+- [marcmerlin](https://github.com/marcmerlin): Contributor (ESP32 port)
 
 Note: This list is being updated constantly so please let [z3t0](https://github.com/z3t0) know if you have been missed.

--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -18,15 +18,16 @@
 // Whynter A/C ARC-110WD added by Francesco Meschia
 //******************************************************************************
 
-#ifndef ESP32
-#include <avr/interrupt.h>
-#endif
-
 // Defining IR_GLOBAL here allows us to declare the instantiation of global variables
 #define IR_GLOBAL
 #	include "IRremote.h"
 #	include "IRremoteInt.h"
 #undef IR_GLOBAL
+
+#ifndef IR_TIMER_USE_ESP32
+#include <avr/interrupt.h>
+#endif
+
 
 //+=============================================================================
 // The match functions were (apparently) originally MACROs to improve code speed
@@ -122,7 +123,7 @@ int  MATCH_SPACE (int measured_ticks,  int desired_us)
 // As soon as first MARK arrives:
 //   Gap width is recorded; Ready is cleared; New logging starts
 //
-#ifdef ESP32
+#ifdef IR_TIMER_USE_ESP32
 void IRTimer()
 #else
 ISR (TIMER_INTR_NAME)

--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -18,7 +18,9 @@
 // Whynter A/C ARC-110WD added by Francesco Meschia
 //******************************************************************************
 
+#ifndef ESP32
 #include <avr/interrupt.h>
+#endif
 
 // Defining IR_GLOBAL here allows us to declare the instantiation of global variables
 #define IR_GLOBAL
@@ -120,7 +122,11 @@ int  MATCH_SPACE (int measured_ticks,  int desired_us)
 // As soon as first MARK arrives:
 //   Gap width is recorded; Ready is cleared; New logging starts
 //
+#ifdef ESP32
+void onTimer()
+#else
 ISR (TIMER_INTR_NAME)
+#endif
 {
 	TIMER_RESET;
 

--- a/IRremote.cpp
+++ b/IRremote.cpp
@@ -123,7 +123,7 @@ int  MATCH_SPACE (int measured_ticks,  int desired_us)
 //   Gap width is recorded; Ready is cleared; New logging starts
 //
 #ifdef ESP32
-void onTimer()
+void IRTimer()
 #else
 ISR (TIMER_INTR_NAME)
 #endif

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ We are open to suggestions for adding support to new boards, however we highly r
 | [ATmega8535 ATmega16, ATmega32](https://github.com/MCUdude/MightyCore)   | **13**              | **1**             |
 | [ATmega64, ATmega128](https://github.com/MCUdude/MegaCore)               | **13**              | **1**             |
 | ATmega1280, ATmega2560                                                   | 5, 6, **9**, 11, 46 | 1, **2**, 3, 4, 5 |
+| [ESP32](http://esp32.net/)                                               | N/A (not supported) | **1**             |
 | [Teensy 1.0](https://www.pjrc.com/teensy/)                               | **17**              | **1**             |
 | [Teensy 2.0](https://www.pjrc.com/teensy/)                               | 9, **10**, 14       | 1, 3, **4_HS**    |
 | [Teensy++ 1.0 / 2.0](https://www.pjrc.com/teensy/)                       | **1**, 16, 25       | 1, **2**, 3       |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Tutorials and more information will be made available on [the official homepage]
 - ATmega8535, 16, 32, 164, 324, 644, 1284,
 - ATmega64, 128
 - ATtiny 84 / 85
+- ESP32 (receive only)
 
 We are open to suggestions for adding support to new boards, however we highly recommend you contact your supplier first and ask them to provide support from their side.
 

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -39,13 +39,14 @@
 #	define BLINKLED_ON()   (PORTD |= B00000001)
 #	define BLINKLED_OFF()  (PORTD &= B11111110)
 
+// No system LED on ESP32, disable blinking
 #elif defined(ESP32)
 #	define BLINKLED        255
 #	define BLINKLED_ON()   1
 #	define BLINKLED_OFF()  1
 #else
 #	define BLINKLED        13
-	#define BLINKLED_ON()  (PORTB |= B00100000)
+#	define BLINKLED_ON()  (PORTB |= B00100000)
 #	define BLINKLED_OFF()  (PORTB &= B11011111)
 #endif
 
@@ -129,14 +130,16 @@
 
 // ATtiny84
 #elif defined(__AVR_ATtiny84__)
-  #define IR_USE_TIMER1     // tx = pin 6
+	#define IR_USE_TIMER1     // tx = pin 6
 
 //ATtiny85
 #elif defined(__AVR_ATtiny85__)
-  #define IR_USE_TIMER_TINY0   // tx = pin 1
+	#define IR_USE_TIMER_TINY0   // tx = pin 1
 
 // Arduino Duemilanove, Diecimila, LilyPad, Mini, Fio, Nano, etc
 // ATmega48, ATmega88, ATmega168, ATmega328
+#elif defined(ESP32)
+	#define IR_TIMER_USE_ESP32
 #else
 	//#define IR_USE_TIMER1   // tx = pin 9
 	#define IR_USE_TIMER2     // tx = pin 3
@@ -151,21 +154,12 @@
 //
 #if defined(IR_USE_TIMER2)
 
-#ifdef ESP32 // Used in irSend, not implemented yet (FIXME)
-#define TIMER_RESET	    1
-#define TIMER_ENABLE_PWM    1
-#define TIMER_DISABLE_PWM   Serial.println("IRsend not implemented for ESP32 yet");
-#define TIMER_ENABLE_INTR   1
-#define TIMER_DISABLE_INTR  1
-#define TIMER_INTR_NAME     1
-#else
 #define TIMER_RESET
 #define TIMER_ENABLE_PWM    (TCCR2A |= _BV(COM2B1))
 #define TIMER_DISABLE_PWM   (TCCR2A &= ~(_BV(COM2B1)))
 #define TIMER_ENABLE_INTR   (TIMSK2 = _BV(OCIE2A))
 #define TIMER_DISABLE_INTR  (TIMSK2 = 0)
 #define TIMER_INTR_NAME     TIMER2_COMPA_vect
-#endif
 
 #define TIMER_CONFIG_KHZ(val) ({ \
 	const uint8_t pwmval = SYSCLOCK / 2000 / (val); \
@@ -550,6 +544,28 @@
 #endif
 
 #define TIMER_PWM_PIN        1  /* ATtiny85 */
+
+//---------------------------------------------------------
+// ESP32 (ESP8266 should likely be added here too)
+//
+
+// ESP32 has it own timer API and does not use these macros, but to avoid ifdef'ing
+// them out in the common code, they are defined to no-op. This allows the code to compile
+// (which it wouldn't otherwise) but irsend will not work until ESP32 specific code is written
+// for that -- merlin
+// As a warning, sending timing specific code from an ESP32 can be challenging if you need 100%
+// reliability because the arduino code may be interrupted and cause your sent waveform to be the
+// wrong length. This is specifically an issue for neopixels which require 800Khz resolution.
+// IR may just work as is with the common code since it's lower frequency, but if not, the other
+// way to do this on ESP32 is using the RMT built in driver like in this incomplete library below
+// https://github.com/ExploreEmbedded/ESP32_RMT
+#elif defined(IR_TIMER_USE_ESP32)
+#define TIMER_RESET	    1
+#define TIMER_ENABLE_PWM    1
+#define TIMER_DISABLE_PWM   Serial.println("IRsend not implemented for ESP32 yet");
+#define TIMER_ENABLE_INTR   1
+#define TIMER_DISABLE_INTR  1
+#define TIMER_INTR_NAME     1
 
 //---------------------------------------------------------
 // Unknown Timer

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -560,12 +560,12 @@
 // way to do this on ESP32 is using the RMT built in driver like in this incomplete library below
 // https://github.com/ExploreEmbedded/ESP32_RMT
 #elif defined(IR_TIMER_USE_ESP32)
-#define TIMER_RESET	    1
-#define TIMER_ENABLE_PWM    1
+#define TIMER_RESET	     
+#define TIMER_ENABLE_PWM     
 #define TIMER_DISABLE_PWM   Serial.println("IRsend not implemented for ESP32 yet");
-#define TIMER_ENABLE_INTR   1
-#define TIMER_DISABLE_INTR  1
-#define TIMER_INTR_NAME     1
+#define TIMER_ENABLE_INTR    
+#define TIMER_DISABLE_INTR   
+#define TIMER_INTR_NAME      
 
 //---------------------------------------------------------
 // Unknown Timer

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -136,11 +136,11 @@
 #elif defined(__AVR_ATtiny85__)
 	#define IR_USE_TIMER_TINY0   // tx = pin 1
 
-// Arduino Duemilanove, Diecimila, LilyPad, Mini, Fio, Nano, etc
-// ATmega48, ATmega88, ATmega168, ATmega328
 #elif defined(ESP32)
 	#define IR_TIMER_USE_ESP32
 #else
+// Arduino Duemilanove, Diecimila, LilyPad, Mini, Fio, Nano, etc
+// ATmega48, ATmega88, ATmega168, ATmega328
 	//#define IR_USE_TIMER1   // tx = pin 9
 	#define IR_USE_TIMER2     // tx = pin 3
 

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -39,6 +39,10 @@
 #	define BLINKLED_ON()   (PORTD |= B00000001)
 #	define BLINKLED_OFF()  (PORTD &= B11111110)
 
+#elif defined(ESP32)
+#	define BLINKLED        255
+#	define BLINKLED_ON()   1
+#	define BLINKLED_OFF()  1
 #else
 #	define BLINKLED        13
 	#define BLINKLED_ON()  (PORTB |= B00100000)
@@ -147,12 +151,21 @@
 //
 #if defined(IR_USE_TIMER2)
 
+#ifdef ESP32 // Used in irSend, not implemented yet (FIXME)
+#define TIMER_RESET	    1
+#define TIMER_ENABLE_PWM    1
+#define TIMER_DISABLE_PWM   Serial.println("IRsend not implemented for ESP32 yet");
+#define TIMER_ENABLE_INTR   1
+#define TIMER_DISABLE_INTR  1
+#define TIMER_INTR_NAME     1
+#else
 #define TIMER_RESET
 #define TIMER_ENABLE_PWM    (TCCR2A |= _BV(COM2B1))
 #define TIMER_DISABLE_PWM   (TCCR2A &= ~(_BV(COM2B1)))
 #define TIMER_ENABLE_INTR   (TIMSK2 = _BV(OCIE2A))
 #define TIMER_DISABLE_INTR  (TIMSK2 = 0)
 #define TIMER_INTR_NAME     TIMER2_COMPA_vect
+#endif
 
 #define TIMER_CONFIG_KHZ(val) ({ \
 	const uint8_t pwmval = SYSCLOCK / 2000 / (val); \

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## 2.2.4 - 2017/03/31
+- Added ESP32 IR receive support [PR #427](https://github.com/z3t0/Arduino-IRremote/pull/425)
+
 ## 2.2.3 - 2017/03/27
 - Fix calculation of pause length in LEGO PF protocol [PR #427](https://github.com/z3t0/Arduino-IRremote/pull/427)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-## 2.2.4 - 2017/03/31
+## 2.3.3 - 2017/03/31
 - Added ESP32 IR receive support [PR #427](https://github.com/z3t0/Arduino-IRremote/pull/425)
 
 ## 2.2.3 - 2017/03/27

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -8,7 +8,11 @@
 
 #include <IRremote.h>
 
+#ifdef ESP32
+int RECV_PIN = 35;
+#else
 int RECV_PIN = 11;
+#endif
 
 IRrecv irrecv(RECV_PIN);
 
@@ -16,8 +20,10 @@ decode_results results;
 
 void setup()
 {
-  Serial.begin(9600);
+  Serial.begin(115200);
+  Serial.println("Enabling IRin");
   irrecv.enableIRIn(); // Start the receiver
+  Serial.println("Enabled IRin");
 }
 
 void loop() {

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -8,11 +8,7 @@
 
 #include <IRremote.h>
 
-#ifdef ESP32
-int RECV_PIN = 35;
-#else
 int RECV_PIN = 11;
-#endif
 
 IRrecv irrecv(RECV_PIN);
 
@@ -20,7 +16,9 @@ decode_results results;
 
 void setup()
 {
-  Serial.begin(115200);
+  Serial.begin(9600);
+  // In case the interrupt driver crashes on setup, give a clue
+  // to the user what's going on.
   Serial.println("Enabling IRin");
   irrecv.enableIRIn(); // Start the receiver
   Serial.println("Enabled IRin");

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -15,7 +15,11 @@
 *  You can change this to another available Arduino Pin.
 *  Your IR receiver should be connected to the pin defined here
 */
-int RECV_PIN = 11; 
+#ifdef ESP32
+int RECV_PIN = 35;
+#else
+int RECV_PIN = 11;
+#endif
 
 IRrecv irrecv(RECV_PIN);
 
@@ -23,7 +27,7 @@ decode_results results;
 
 void setup()
 {
-  Serial.begin(9600);
+  Serial.begin(115200);
   irrecv.enableIRIn(); // Start the receiver
 }
 

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -15,11 +15,7 @@
 *  You can change this to another available Arduino Pin.
 *  Your IR receiver should be connected to the pin defined here
 */
-#ifdef ESP32
-int RECV_PIN = 35;
-#else
 int RECV_PIN = 11;
-#endif
 
 IRrecv irrecv(RECV_PIN);
 

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -23,7 +23,7 @@ decode_results results;
 
 void setup()
 {
-  Serial.begin(115200);
+  Serial.begin(9600);
   irrecv.enableIRIn(); // Start the receiver
 }
 

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 // Tell IRremote which Arduino pin is connected to the IR Receiver (TSOP4838)
 //
-int recvPin = 35;
+int recvPin = 11;
 IRrecv irrecv(recvPin);
 
 //+=============================================================================
@@ -14,7 +14,7 @@ IRrecv irrecv(recvPin);
 //
 void  setup ( )
 {
-  Serial.begin(115200);   // Status message will be sent to PC at 9600 baud
+  Serial.begin(9600);   // Status message will be sent to PC at 9600 baud
   irrecv.enableIRIn();  // Start the receiver
 }
 

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 // Tell IRremote which Arduino pin is connected to the IR Receiver (TSOP4838)
 //
-int recvPin = 11;
+int recvPin = 35;
 IRrecv irrecv(recvPin);
 
 //+=============================================================================
@@ -14,7 +14,7 @@ IRrecv irrecv(recvPin);
 //
 void  setup ( )
 {
-  Serial.begin(9600);   // Status message will be sent to PC at 9600 baud
+  Serial.begin(115200);   // Status message will be sent to PC at 9600 baud
   irrecv.enableIRIn();  // Start the receiver
 }
 

--- a/irRecv.cpp
+++ b/irRecv.cpp
@@ -1,7 +1,7 @@
 #include "IRremote.h"
 #include "IRremoteInt.h"
 
-#ifdef ESP32
+#ifdef IR_TIMER_USE_ESP32
 hw_timer_t *timer;
 void IRTimer(); // defined in IRremote.cpp
 #endif

--- a/irRecv.cpp
+++ b/irRecv.cpp
@@ -124,6 +124,8 @@ void  IRrecv::enableIRIn ( )
 {
 // Interrupt Service Routine - Fires every 50uS
 #ifdef ESP32
+	// ESP32 has a proper API to setup timers, no weird chip macros needed
+	// simply call the readable API versions :)
 	// 3 timers, choose #1, 80 divider nanosecond precision, 1 to count up
 	timer = timerBegin(1, 80, 1);
 	timerAttachInterrupt(timer, &IRTimer, 1);

--- a/irRecv.cpp
+++ b/irRecv.cpp
@@ -3,7 +3,7 @@
 
 #ifdef ESP32
 hw_timer_t *timer;
-void onTimer(); // defined in IRremote.cpp
+void IRTimer(); // defined in IRremote.cpp
 #endif
 
 //+=============================================================================
@@ -126,7 +126,7 @@ void  IRrecv::enableIRIn ( )
 #ifdef ESP32
 	// 3 timers, choose #1, 80 divider nanosecond precision, 1 to count up
 	timer = timerBegin(1, 80, 1);
-	timerAttachInterrupt(timer, &onTimer, 1);
+	timerAttachInterrupt(timer, &IRTimer, 1);
 	// every 50ns, autoreload = true
 	timerAlarmWrite(timer, 50, true);
 	timerAlarmEnable(timer);

--- a/irSend.cpp
+++ b/irSend.cpp
@@ -54,6 +54,8 @@ void  IRsend::space (unsigned int time)
 //
 void  IRsend::enableIROut (int khz)
 {
+// FIXME: implement ESP32 support
+#ifndef ESP32
 	// Disable the Timer2 Interrupt (which is used for receiving IR)
 	TIMER_DISABLE_INTR; //Timer2 Overflow Interrupt
 
@@ -66,6 +68,7 @@ void  IRsend::enableIROut (int khz)
 	// CS2  = 000: no prescaling
 	// The top value for the timer.  The modulation frequency will be SYSCLOCK / 2 / OCR2A.
 	TIMER_CONFIG_KHZ(khz);
+#endif
 }
 
 //+=============================================================================

--- a/irSend.cpp
+++ b/irSend.cpp
@@ -54,7 +54,7 @@ void  IRsend::space (unsigned int time)
 //
 void  IRsend::enableIROut (int khz)
 {
-// FIXME: implement ESP32 support
+// FIXME: implement ESP32 support, see IR_TIMER_USE_ESP32 in boarddefs.h
 #ifndef ESP32
 	// Disable the Timer2 Interrupt (which is used for receiving IR)
 	TIMER_DISABLE_INTR; //Timer2 Overflow Interrupt

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/z3t0/Arduino-IRremote.git"
   },
-  "version": "2.2.3",
+  "version": "2.2.4",
   "frameworks": "arduino",
   "platforms": "atmelavr",
   "authors" :

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/z3t0/Arduino-IRremote.git"
   },
-  "version": "2.2.4",
+  "version": "2.3.3",
   "frameworks": "arduino",
   "platforms": "atmelavr",
   "authors" :


### PR DESCRIPTION
- disable a lot of defines not relevant to ESP32, set them to 1 (no-op)
- change default IR pin to 35 from 11
- changed serial speed to 115200 (9600 is too slow to keep up with IR input)
- irSend disables code that will not compile on ESP32. It won't work,
  but it won't break compilation either.