### PR TITLE
Fix incorrect frequency used for Panasonic

### DIFF
--- a/ir_Panasonic.cpp
+++ b/ir_Panasonic.cpp
@@ -21,7 +21,7 @@
 void  IRsend::sendPanasonic (unsigned int address,  unsigned long data)
 {
 	// Set IR carrier frequency
-	enableIROut(35);
+	enableIROut(37);
 
 	// Header
 	mark(PANASONIC_HDR_MARK);


### PR DESCRIPTION
All the references I can find indicate that the 48 bit (Kaseikyu-like) Panasonic protocol uses 37kHz, not 35kHz.
IR codes from GlobalCache.com confirm it as well. e.g.
`"POWER OFF","sendir,1:1,1,37000,1,1,128,63,16,16,16,48,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,48,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,48,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,48,16,48,16,48,16,48,16,48,16,48,16,16,16,16,16,48,16,48,16,48,16,48,16,48,16,48,16,16,16,48,16,2712","0000 0070 0000 0032 0080 003f 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0010 0030 0010 0030 0010 0030 0010 0030 0010 0030 0010 0030 0010 0010 0010 0010 0010 0030 0010 0030 0010 0030 0010 0030 0010 0030 0010 0030 0010 0010 0010 0030 0010 0a98",,`

Additional refs:
  http://www.hifi-remote.com/wiki/index.php?title=Panasonic
  http://www.hifi-remote.com/wiki/index.php?title=Kaseikyo
  http://www.remotecentral.com/cgi-bin/mboard/rc-pronto/thread.cgi?26152

Might fix #126.

This was discovered as I was reworking https://github.com/markszabo/IRremoteESP8266 for v2.0.