### PR TITLE
Added Esp32 IrSend Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Whether you use the Adafruit Neopixel lib, or FastLED, interrupts get disabled o
 - ATmega8535, 16, 32, 164, 324, 644, 1284,
 - ATmega64, 128
 - ATtiny 84 / 85
-- ESP32 (receive only)
+- ESP32
 - ESP8266 is supported in a fork based on an old codebase that isn't as recent, but it works reasonably well given that perfectly timed sub millisecond interrupts are different on that chip. See https://github.com/markszabo/IRremoteESP8266
 
 We are open to suggestions for adding support to new boards, however we highly recommend you contact your supplier first and ask them to provide support from their side.
@@ -50,7 +50,7 @@ We are open to suggestions for adding support to new boards, however we highly r
 | [ATmega8535 ATmega16, ATmega32](https://github.com/MCUdude/MightyCore)   | **13**              | **1**             |
 | [ATmega64, ATmega128](https://github.com/MCUdude/MegaCore)               | **13**              | **1**             |
 | ATmega1280, ATmega2560                                                   | 5, 6, **9**, 11, 46 | 1, **2**, 3, 4, 5 |
-| [ESP32](http://esp32.net/)                                               | N/A (not supported) | **1**             |
+| [ESP32](http://esp32.net/)                                               | **5** configurable in boarddefs.h | **1**             |
 | [Teensy 1.0](https://www.pjrc.com/teensy/)                               | **17**              | **1**             |
 | [Teensy 2.0](https://www.pjrc.com/teensy/)                               | 9, **10**, 14       | 1, 3, **4_HS**    |
 | [Teensy++ 1.0 / 2.0](https://www.pjrc.com/teensy/)                       | **1**, 16, 25       | 1, **2**, 3       |

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -560,9 +560,12 @@
 // way to do this on ESP32 is using the RMT built in driver like in this incomplete library below
 // https://github.com/ExploreEmbedded/ESP32_RMT
 #elif defined(IR_TIMER_USE_ESP32)
-#define TIMER_RESET	     
-#define TIMER_ENABLE_PWM     
-#define TIMER_DISABLE_PWM   Serial.println("IRsend not implemented for ESP32 yet");
+#define TIMER_CHANNEL       1
+#define TIMER_LENGHT        8 //8-bit Timer
+#define TIMER_PWM_PIN       5    
+#define TIMER_ENABLE_PWM    ledcAttachPin(TIMER_PWM_PIN, TIMER_CHANNEL); 		 
+#define TIMER_DISABLE_PWM   ledcDetachPin(TIMER_PWM_PIN); 
+#define TIMER_RESET	 
 #define TIMER_ENABLE_INTR    
 #define TIMER_DISABLE_INTR   
 #define TIMER_INTR_NAME      

--- a/irSend.cpp
+++ b/irSend.cpp
@@ -54,8 +54,10 @@ void  IRsend::space (unsigned int time)
 //
 void  IRsend::enableIROut (int khz)
 {
-// FIXME: implement ESP32 support, see IR_TIMER_USE_ESP32 in boarddefs.h
-#ifndef ESP32
+#ifdef ESP32
+         ledcSetup(TIMER_CHANNEL, khz*1000, TIMER_LENGHT); // channel, freq, timerLength		 
+         ledcWrite(TIMER_CHANNEL, (1<<(TIMER_LENGHT-1))); //50% Duty Cycle
+#else
 	// Disable the Timer2 Interrupt (which is used for receiving IR)
 	TIMER_DISABLE_INTR; //Timer2 Overflow Interrupt
 


### PR DESCRIPTION
IrSend Support for ESP32
Used ledc funtions for generating IR signals.
Mapped Pin 5 for IrSend.