### PR TITLE
Add XiaoMi1 support.

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -18,5 +18,6 @@ These are the active contributors of this project that you may contact if there 
 - [philipphenkel](https://github.com/philipphenkel): Active Contributor
 - [MCUdude](https://github.com/MCUdude): Contributor
 - [marcmerlin](https://github.com/marcmerlin): Contributor (ESP32 port)
+- [Anders Liu](https://github.com/anders-liu): Contributor (Xiao Mi I)
 
 Note: This list is being updated constantly so please let [z3t0](https://github.com/z3t0) know if you have been missed.

--- a/IRremote.h
+++ b/IRremote.h
@@ -76,8 +76,8 @@
 #define DECODE_PRONTO        0 // This function doe not logically make sense
 #define SEND_PRONTO          1
 
-#define DECODE_LEGO_PF       0 // NOT WRITTEN
-#define SEND_LEGO_PF         1
+#define DECODE_XIAOMI1         1
+#define SEND_XIAOMI1           0 // NOT WRITTEN
 
 //------------------------------------------------------------------------------
 // When sending a Pronto code we request to send either the "once" code
@@ -119,6 +119,7 @@ typedef
 		DENON,
 		PRONTO,
 		LEGO_PF,
+		XIAOMI1,
 	}
 decode_type_t;
 
@@ -247,9 +248,13 @@ class IRrecv
 #		if DECODE_DENON
 			bool  decodeDenon (decode_results *results) ;
 #		endif
-//......................................................................
+		//......................................................................
 #		if DECODE_LEGO_PF
 			bool  decodeLegoPowerFunctions (decode_results *results) ;
+#		endif
+		//......................................................................
+#		if DECODE_XIAOMI1
+			bool  decodeXiaoMi1 (decode_results *results) ;
 #		endif
 } ;
 

--- a/IRremote.h
+++ b/IRremote.h
@@ -76,6 +76,9 @@
 #define DECODE_PRONTO        0 // This function doe not logically make sense
 #define SEND_PRONTO          1
 
+#define DECODE_LEGO_PF       0 // NOT WRITTEN
+#define SEND_LEGO_PF         1
+
 #define DECODE_XIAOMI1         1
 #define SEND_XIAOMI1           0 // NOT WRITTEN
 

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -26,6 +26,9 @@ void setup()
 
 void loop() {
   if (irrecv.decode(&results)) {
+    if(results.decode_type == UNKNOWN)
+      Serial.print("[UNKNOWN] ");  // Unknown result has a hash value, so mark it.
+
     Serial.println(results.value, HEX);
     irrecv.resume(); // Receive the next value
   }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -56,6 +56,7 @@ void  encoding (decode_results *results)
     case AIWA_RC_T501: Serial.print("AIWA_RC_T501");  break ;
     case PANASONIC:    Serial.print("PANASONIC");     break ;
     case DENON:        Serial.print("Denon");         break ;
+    case XIAOMI1:      Serial.print("Xiao Mi 1");     break ;
   }
 }
 

--- a/irRecv.cpp
+++ b/irRecv.cpp
@@ -90,6 +90,11 @@ int  IRrecv::decode (decode_results *results)
 	if (decodeLegoPowerFunctions(results))  return true ;
 #endif
 
+#if DECODE_XIAOMI1
+	DBG_PRINTLN("Attempting Xiao Mi 1 decode");
+	if (decodeXiaoMi1(results))  return true ;
+#endif
+
 	// decodeHash returns a hash on any input.
 	// Thus, it needs to be last in the list.
 	// If you add any decodes, add them before this.

--- a/ir_XiaoMi1.cpp
+++ b/ir_XiaoMi1.cpp
@@ -1,0 +1,67 @@
+#include "IRremote.h"
+#include "IRremoteInt.h"
+
+//==============================================================================
+//         X   X  III    A     ooo     M   M  III    1
+//          X X    I   A   A  o   o    MM MM   I    11
+//           X     I   A   A  o   o    M M M   I     1
+//          X X    I   A A A  o   o    M   M   I     1
+//         X   X  III  A   A   ooo     M   M  III   111
+//
+// 1st generation of Xiao Mi IR remote controller,
+// used on Xiao Mi Box I, Made In China.
+//==============================================================================
+
+// Xiao Mi 1 uses quaternary system, 1 bit has four values.
+#define XIAOMI1_0SPACE ((unsigned int)11)
+#define XIAOMI1_1SPACE ((unsigned int)17)
+#define XIAOMI1_2SPACE ((unsigned int)23)
+#define XIAOMI1_3SPACE ((unsigned int)29)
+
+// 11-bit of quaternary data.
+#define XIAOMI1_BITS 11
+
+#define XIAOMI1_MARK ((unsigned int)12)
+#define XIAOMI1_HDR_MARK ((unsigned int)21)
+
+#define XIAOMI1_TOLERANCE ((unsigned int)3)
+
+#define XIAOMI1_MATCH(measured_ticks, desired_ticks)            \
+	((measured_ticks) >= ((desired_ticks) - XIAOMI1_TOLERANCE) && \
+	 (measured_ticks) <= ((desired_ticks) + XIAOMI1_TOLERANCE))
+
+//+=============================================================================
+#if DECODE_XIAOMI1
+bool IRrecv::decodeXiaoMi1(decode_results *results)
+{
+	unsigned long  data   = 0;  // Somewhere to build our code
+	int            offset = 1;  // Skip the Gap reading
+
+	if (results->rawlen != 24) return false;
+
+	// Check header "mark"
+	if (!XIAOMI1_MATCH(results->rawbuf[offset], XIAOMI1_HDR_MARK)) return false;
+	offset++;
+
+	// Read the bits in
+	for (int i = 0;  i < XIAOMI1_BITS;  i++) {
+		// IR data is big-endian, so we shuffle it in from the right:
+		if      (XIAOMI1_MATCH(results->rawbuf[offset], XIAOMI1_0SPACE)) data = (data << 2) | 0 ;
+		else if (XIAOMI1_MATCH(results->rawbuf[offset], XIAOMI1_1SPACE)) data = (data << 2) | 1 ;
+		else if (XIAOMI1_MATCH(results->rawbuf[offset], XIAOMI1_2SPACE)) data = (data << 2) | 2 ;
+		else if (XIAOMI1_MATCH(results->rawbuf[offset], XIAOMI1_3SPACE)) data = (data << 2) | 3 ;
+		else return false ;
+		offset++;
+
+		// Match a mark
+		if (!XIAOMI1_MATCH(results->rawbuf[offset], XIAOMI1_MARK)) return false;
+		offset++;
+	}
+
+	// Success
+	results->bits        = XIAOMI1_BITS * 2;  // 1 quaternary bit equal to 2 binary bits.
+	results->value       = data;
+	results->decode_type = XIAOMI1;
+	return true;
+}
+#endif


### PR DESCRIPTION
Add supporting to Xiao Mi 1st generation IR remote controller, which is used on Xiao Mi Box I.

Only support to receiving data.

Xiao Mi uses a weird quaternary system to encode data, so it's a little bit different from other remote controllers.