### PR TITLE
Sparkfun Pro Micro Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ We are open to suggestions for adding support to new boards, however we highly r
 | [ATmega64, ATmega128](https://github.com/MCUdude/MegaCore)               | **13**              | **1**             |
 | ATmega1280, ATmega2560                                                   | 5, 6, **9**, 11, 46 | 1, **2**, 3, 4, 5 |
 | [ESP32](http://esp32.net/)                                               | N/A (not supported) | **1**             |
+| [Sparkfun Pro Micro](https://www.sparkfun.com/products/12640)            | 9, **5**, 5         | 1, **3**, 4_HS    |
 | [Teensy 1.0](https://www.pjrc.com/teensy/)                               | **17**              | **1**             |
 | [Teensy 2.0](https://www.pjrc.com/teensy/)                               | 9, **10**, 14       | 1, 3, **4_HS**    |
 | [Teensy++ 1.0 / 2.0](https://www.pjrc.com/teensy/)                       | **1**, 16, 25       | 1, **2**, 3       |
 | [Teensy 3.0 / 3.1](https://www.pjrc.com/teensy/)                         | **5**               | **CMT**           |
 | [Teensy-LC](https://www.pjrc.com/teensy/)                                | **16**              | **TPM1**          |
-| [Sparkfun Pro Micro](https://www.sparkfun.com/products/12640)            | 9, **5**, 5         | 1, **3**, 4_HS    |
 
 
 ### Experimental patches

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We are open to suggestions for adding support to new boards, however we highly r
 | [Teensy++ 1.0 / 2.0](https://www.pjrc.com/teensy/)                       | **1**, 16, 25       | 1, **2**, 3       |
 | [Teensy 3.0 / 3.1](https://www.pjrc.com/teensy/)                         | **5**               | **CMT**           |
 | [Teensy-LC](https://www.pjrc.com/teensy/)                                | **16**              | **TPM1**          |
-| [Sparkfun Pro Micro](https://www.sparkfun.com/products/12640)            | 9, **5**, 5         | 1, **3**, 4       |
+| [Sparkfun Pro Micro](https://www.sparkfun.com/products/12640)            | 9, **5**, 5         | 1, **3**, 4_HS    |
 
 
 ### Experimental patches

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Whether you use the Adafruit Neopixel lib, or FastLED, interrupts get disabled o
 - ATtiny 84 / 85
 - ESP32 (receive only)
 - ESP8266 is supported in a fork based on an old codebase that isn't as recent, but it works reasonably well given that perfectly timed sub millisecond interrupts are different on that chip. See https://github.com/markszabo/IRremoteESP8266
+- Sparkfun Pro Micro
 
 We are open to suggestions for adding support to new boards, however we highly recommend you contact your supplier first and ask them to provide support from their side.
 
@@ -56,6 +57,7 @@ We are open to suggestions for adding support to new boards, however we highly r
 | [Teensy++ 1.0 / 2.0](https://www.pjrc.com/teensy/)                       | **1**, 16, 25       | 1, **2**, 3       |
 | [Teensy 3.0 / 3.1](https://www.pjrc.com/teensy/)                         | **5**               | **CMT**           |
 | [Teensy-LC](https://www.pjrc.com/teensy/)                                | **16**              | **TPM1**          |
+| [Sparkfun Pro Micro](https://www.sparkfun.com/products/12640)            | 9, **5**, 5         | 1, **3**, 4       |
 
 
 ### Experimental patches

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -252,7 +252,6 @@
 #	define TIMER_PWM_PIN  CORE_OC1A_PIN  // Teensy
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  11             // Arduino Mega
-#elif
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) \
 || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) \
 || defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324A__) \
@@ -261,7 +260,7 @@
 || defined(__AVR_ATmega16__) || defined(__AVR_ATmega8535__) \
 || defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
 #	define TIMER_PWM_PIN  13             // MightyCore, // MegaCore
-#elif defined(__AVR_ATtiny84__) || 
+#elif defined(__AVR_ATtiny84__)
 # 	define TIMER_PWM_PIN  6          
 #else
 #	define TIMER_PWM_PIN  9              // Arduino Duemilanove, Diecimila, LilyPad, Sparkfun Pro Micro etc
@@ -311,11 +310,20 @@
 #elif defined(IR_USE_TIMER4_HS)
 
 #define TIMER_RESET
-#define TIMER_ENABLE_PWM    (TCCR4A |= _BV(COM4A1))
-#define TIMER_DISABLE_PWM   (TCCR4A &= ~(_BV(COM4A1)))
+
+#if defined(ARDUINO_AVR_PROMICRO) // Sparkfun Pro Micro                         
+	#define TIMER_ENABLE_PWM    (TCCR4A |= _BV(COM4A0))     // Use complimentary O̅C̅4̅A̅ output on pin 5
+	#define TIMER_DISABLE_PWM   (TCCR4A &= ~(_BV(COM4A0)))  // (Pro Micro does not map PC7 (32/ICP3/CLK0/OC4A)
+															// of ATmega32U4 )
+#else
+	#define TIMER_ENABLE_PWM    (TCCR4A |= _BV(COM4A1))
+	#define TIMER_DISABLE_PWM   (TCCR4A &= ~(_BV(COM4A1)))
+#endif
+
 #define TIMER_ENABLE_INTR   (TIMSK4 = _BV(TOIE4))
 #define TIMER_DISABLE_INTR  (TIMSK4 = 0)
 #define TIMER_INTR_NAME     TIMER4_OVF_vect
+
 
 #define TIMER_CONFIG_KHZ(val) ({ \
 	const uint16_t pwmval = SYSCLOCK / 2000 / (val); \

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -261,7 +261,7 @@
 || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega32__) \
 || defined(__AVR_ATmega16__) || defined(__AVR_ATmega8535__) \
 || defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
-#	define TIMER_PWM_PIN  13             // MightyCore, // MegaCore
+#	define TIMER_PWM_PIN  13             // MightyCore, MegaCore
 #elif defined(__AVR_ATtiny84__)
 # 	define TIMER_PWM_PIN  6
 #else

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -15,6 +15,8 @@
 //
 // JVC and Panasonic protocol added by Kristian Lauszus (Thanks to zenwheel and other people at the original blog post)
 // Whynter A/C ARC-110WD added by Francesco Meschia
+
+// Sparkfun Pro Micro support by Alastair McCormack
 //******************************************************************************
 
 #ifndef boarddefs_h

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -70,8 +70,14 @@
 //   switch IRremote to use a different timer.
 //
 
+// Sparkfun Pro Micro
+#if defined(ARDUINO_AVR_PROMICRO)
+	//#define IR_USE_TIMER1     // tx = pin 9
+	#define IR_USE_TIMER3       // tx = pin 5
+	//#define IR_USE_TIMER4_HS  // tx = pin 5
+
 // Arduino Mega
-#if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+#elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 	//#define IR_USE_TIMER1   // tx = pin 11
 	#define IR_USE_TIMER2     // tx = pin 9
 	//#define IR_USE_TIMER3   // tx = pin 5
@@ -246,19 +252,19 @@
 #	define TIMER_PWM_PIN  CORE_OC1A_PIN  // Teensy
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
 #	define TIMER_PWM_PIN  11             // Arduino Mega
-#elif defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
-#	define TIMER_PWM_PIN  13	     // MegaCore
+#elif
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__) \
 || defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) \
 || defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324A__) \
 || defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega164A__) \
 || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega32__) \
-|| defined(__AVR_ATmega16__) || defined(__AVR_ATmega8535__)
-#	define TIMER_PWM_PIN  13             // MightyCore
-#elif defined(__AVR_ATtiny84__)
-# 	define TIMER_PWM_PIN  6
+|| defined(__AVR_ATmega16__) || defined(__AVR_ATmega8535__) \
+|| defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
+#	define TIMER_PWM_PIN  13             // MightyCore, // MegaCore
+#elif defined(__AVR_ATtiny84__) || 
+# 	define TIMER_PWM_PIN  6          
 #else
-#	define TIMER_PWM_PIN  9              // Arduino Duemilanove, Diecimila, LilyPad, etc
+#	define TIMER_PWM_PIN  9              // Arduino Duemilanove, Diecimila, LilyPad, Sparkfun Pro Micro etc
 #endif					     // ATmega48, ATmega88, ATmega168, ATmega328
 
 //---------------------------------------------------------
@@ -291,8 +297,8 @@
 //-----------------
 #if defined(CORE_OC3A_PIN)
 #	define TIMER_PWM_PIN  CORE_OC3A_PIN  // Teensy
-#elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-#	define TIMER_PWM_PIN  5              // Arduino Mega
+#elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__) || defined(ARDUINO_AVR_PROMICRO)
+#	define TIMER_PWM_PIN  5              // Arduino Mega, Sparkfun Pro Micro
 #elif defined(__AVR_ATmega1284__) || defined(__AVR_ATmega1284P__)
 #	define TIMER_PWM_PIN  6              // MightyCore
 #else
@@ -339,6 +345,8 @@
 //-----------------
 #if defined(CORE_OC4A_PIN)
 #	define TIMER_PWM_PIN  CORE_OC4A_PIN  // Teensy
+#elif defined(ARDUINO_AVR_PROMICRO)
+#	define TIMER_PWM_PIN  5              // Sparkfun Pro Micro
 #elif defined(__AVR_ATmega32U4__)
 #	define TIMER_PWM_PIN  13             // Leonardo
 #else

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -261,7 +261,7 @@
 || defined(__AVR_ATmega64__) || defined(__AVR_ATmega128__)
 #	define TIMER_PWM_PIN  13             // MightyCore, // MegaCore
 #elif defined(__AVR_ATtiny84__)
-# 	define TIMER_PWM_PIN  6          
+# 	define TIMER_PWM_PIN  6
 #else
 #	define TIMER_PWM_PIN  9              // Arduino Duemilanove, Diecimila, LilyPad, Sparkfun Pro Micro etc
 #endif					     // ATmega48, ATmega88, ATmega168, ATmega328


### PR DESCRIPTION
Sparkfun Pro Micro boards are based on the Atmega32u4 chip. The pinout is similar to the Leonardo except that PC7 is not landed (no pin 13). However, Timer4 is available on O̅C̅4̅A̅/PC6/pin 5.

These changes rely on the board being configured in the Arduino IDE according to https://learn.sparkfun.com/tutorials/pro-micro--fio-v3-hookup-guide so that `-DARDUINO_AVR_PROMICRO` is set during compilation.

The changes include a small amount of cleanup around the OC1A pin definition where there was some unnecessary `if` block duplication.
