### PR TITLE
IR receiver emulation

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -364,10 +364,11 @@ class IRsend
 class IRemulate
 {
 	public:
-		IRemulate (int emulatepin);
+		IRemulate (int emulatepin, bool solesource = true);
 
 		void  custom_delay_usec (unsigned long uSecs);
 		void  enableIROut 		() ;
+		void  disableIROut 		() ;
 		void  mark        		(unsigned int usec) ;
 		void  space       		(unsigned int usec) ;
 		void  emulateRaw     		(const unsigned int buf[],  unsigned int len) ;
@@ -447,6 +448,8 @@ class IRemulate
 
 	private:
 		byte emulatepin_;
+		bool solesource_; // Used for specifying if emulator is sole signal source
+		                  // or if it runs on top of an actual IR receiver
 } ;
 
 #endif

--- a/IRremote.h
+++ b/IRremote.h
@@ -30,54 +30,71 @@
 //
 #define DECODE_RC5           1
 #define SEND_RC5             1
+#define EMULATE_RC5          0 // NOT IMPLEMENTED YET
 
 #define DECODE_RC6           1
 #define SEND_RC6             1
+#define EMULATE_RC6          0 // NOT IMPLEMENTED YET
 
 #define DECODE_NEC           1
 #define SEND_NEC             1
+#define EMULATE_NEC          1
 
 #define DECODE_SONY          1
 #define SEND_SONY            1
+#define EMULATE_SONY         0 // NOT IMPLEMENTED YET
 
 #define DECODE_PANASONIC     1
 #define SEND_PANASONIC       1
+#define EMULATE_PANASONIC    0 // NOT IMPLEMENTED YET
 
 #define DECODE_JVC           1
 #define SEND_JVC             1
+#define EMULATE_JVC          0 // NOT IMPLEMENTED YET
 
 #define DECODE_SAMSUNG       1
 #define SEND_SAMSUNG         1
+#define EMULATE_SAMSUNG      0 // NOT IMPLEMENTED YET
 
 #define DECODE_WHYNTER       1
 #define SEND_WHYNTER         1
+#define EMULATE_WHYNTER      0 // NOT IMPLEMENTED YET
 
 #define DECODE_AIWA_RC_T501  1
 #define SEND_AIWA_RC_T501    1
+#define EMULATE_AIWA_RC_T501 0 // NOT IMPLEMENTED YET
 
 #define DECODE_LG            1
 #define SEND_LG              1
+#define EMULATE_LG           0 // NOT IMPLEMENTED YET
 
 #define DECODE_SANYO         1
 #define SEND_SANYO           0 // NOT WRITTEN
+#define EMULATE_SANYO        0 // NOT WRITTEN
 
 #define DECODE_MITSUBISHI    1
 #define SEND_MITSUBISHI      0 // NOT WRITTEN
+#define EMULATE_MITSUBISHI   0 // NOT WRITTEN
 
 #define DECODE_DISH          0 // NOT WRITTEN
 #define SEND_DISH            1
+#define EMULATE_DISH         0 // NOT IMPLEMENTED YET
 
 #define DECODE_SHARP         0 // NOT WRITTEN
 #define SEND_SHARP           1
+#define EMULATE_SHARP        0 // NOT IMPLEMENTED YET
 
 #define DECODE_DENON         1
 #define SEND_DENON           1
+#define EMULATE_DENON        0 // NOT IMPLEMENTED YET
 
 #define DECODE_PRONTO        0 // This function doe not logically make sense
 #define SEND_PRONTO          1
+#define EMULATE_PRONTO       0 // NOT IMPLEMENTED YET
 
 #define DECODE_LEGO_PF       0 // NOT WRITTEN
 #define SEND_LEGO_PF         1
+#define EMULATE_LEGO_PF      0 // NOT IMPLEMENTED YET
 
 //------------------------------------------------------------------------------
 // When sending a Pronto code we request to send either the "once" code
@@ -339,6 +356,97 @@ class IRsend
 #		if SEND_LEGO_PF
 			void  sendLegoPowerFunctions (uint16_t data, bool repeat = true) ;
 #		endif
+} ;
+
+//------------------------------------------------------------------------------
+// Main class for emulating IR receiver
+//
+class IRemulate
+{
+	public:
+		IRemulate (int emulatepin);
+
+		void  custom_delay_usec (unsigned long uSecs);
+		void  enableIROut 		() ;
+		void  mark        		(unsigned int usec) ;
+		void  space       		(unsigned int usec) ;
+		void  emulateRaw     		(const unsigned int buf[],  unsigned int len) ;
+
+		//......................................................................
+#		if EMULATE_RC5
+			// void  emulateRC5        (unsigned long data,  int nbits) ;
+#		endif
+#		if EMULATE_RC6
+			// void  emulateRC6        (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_NEC
+			void  emulateNEC        (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_SONY
+			// void  emulateSony       (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_PANASONIC
+			// void  emulatePanasonic  (unsigned int address,  unsigned long data) ;
+#		endif
+		//......................................................................
+#		if EMULATE_JVC
+			// JVC does NOT repeat by sending a separate code (like NEC does).
+			// The JVC protocol repeats by skipping the header.
+			// To send a JVC repeat signal, send the original code value
+			//   and set 'repeat' to true
+			// void  emulateJVC        (unsigned long data,  int nbits,  bool repeat) ;
+#		endif
+		//......................................................................
+#		if EMULATE_SAMSUNG
+			// void  emulateSAMSUNG    (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_WHYNTER
+			// void  emulateWhynter    (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_AIWA_RC_T501
+			// void  emulateAiwaRCT501 (int code) ;
+#		endif
+		//......................................................................
+#		if EMULATE_LG
+			// void  emulateLG         (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_SANYO
+			// void  emulateSanyo      ( ) ; // NOT WRITTEN
+#		endif
+		//......................................................................
+#		if EMULATE_MISUBISHI
+			// void  emulateMitsubishi ( ) ; // NOT WRITTEN
+#		endif
+		//......................................................................
+#		if EMULATE_DISH
+			// void  emulateDISH       (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_SHARP
+			// void  emulateSharpRaw   (unsigned long data,  int nbits) ;
+			// void  emulateSharp      (unsigned int address,  unsigned int command) ;
+#		endif
+		//......................................................................
+#		if EMULATE_DENON
+			// void  emulateDenon      (unsigned long data,  int nbits) ;
+#		endif
+		//......................................................................
+#		if EMULATE_PRONTO
+			// void  emulatePronto     (char* code,  bool repeat,  bool fallback) ;
+#		endif
+//......................................................................
+#		if EMULATE_LEGO_PF
+			// void  emulateLegoPowerFunctions (uint16_t data, bool repeat = true) ;
+#		endif
+
+	private:
+		byte emulatepin_;
 } ;
 
 #endif

--- a/examples/IRemulateDemo/IRemulateDemo.ino
+++ b/examples/IRemulateDemo/IRemulateDemo.ino
@@ -1,0 +1,25 @@
+/*
+ * IRremote: IRemulateDemo - demonstrates sending IR codes with IRemulate
+ * An IR receiving module like another Arduino with IRrecv code should be attached EMULATE_PIN
+ * Version 0.1 April, 2018
+ * By Kristian Korsgaard
+ */
+
+
+#include <IRremote.h>
+
+int EMULATE_PIN = 2;
+
+IRemulate iremulate(EMULATE_PIN);
+
+void setup()
+{
+}
+
+void loop() {
+	for (int i = 0; i < 3; i++) {
+		iremulate.emulateNEC(0xabcd1234, 32);
+		delay(40);
+	}
+	delay(5000); //5 second delay between each signal
+}

--- a/examples/IRemulateRawDemo/IRemulateRawDemo.ino
+++ b/examples/IRemulateRawDemo/IRemulateRawDemo.ino
@@ -1,0 +1,27 @@
+/*
+ * IRremote: IRemulateRawDemo - demonstrates sending IR codes with emulateRaw
+ * An IR receiving module like another Arduino with IRrecv code should be attached EMULATE_PIN
+ * Version 0.1 April, 2018
+ * By Kristian Korsgaard
+ *
+ */
+
+
+#include <IRremote.h>
+
+int EMULATE_PIN = 2;
+
+IRemulate iremulate(EMULATE_PIN);
+
+void setup()
+{
+
+}
+
+void loop() {
+  unsigned int irSignal[] = {9000, 4500, 560, 560, 560, 560, 560, 1690, 560, 560, 560, 560, 560, 560, 560, 560, 560, 560, 560, 1690, 560, 1690, 560, 560, 560, 1690, 560, 1690, 560, 1690, 560, 1690, 560, 1690, 560, 560, 560, 560, 560, 560, 560, 1690, 560, 560, 560, 560, 560, 560, 560, 560, 560, 1690, 560, 1690, 560, 1690, 560, 560, 560, 1690, 560, 1690, 560, 1690, 560, 1690, 560, 39416, 9000, 2210, 560}; //AnalysIR Batch Export (IRremote) - RAW
+
+  iremulate.emulateRaw(irSignal, sizeof(irSignal) / sizeof(irSignal[0])); //Note the approach used to automatically calculate the size of the array.
+
+  delay(5000); //In this example, the signal will be repeated every 5 seconds, approximately.
+}

--- a/irEmulate.cpp
+++ b/irEmulate.cpp
@@ -1,0 +1,76 @@
+#include "IRremote.h"
+#include "IRremoteInt.h"
+
+//+=============================================================================
+IRemulate::IRemulate (int emulatepin)
+: emulatepin_(emulatepin)
+{
+}
+
+//+=============================================================================
+void  IRemulate::emulateRaw (const unsigned int buf[],  unsigned int len)
+{
+	// Set IR carrier frequency
+	enableIROut();
+
+	for (unsigned int i = 0;  i < len;  i++) {
+		if (i & 1)  space(buf[i]) ;
+		else        mark (buf[i]) ;
+	}
+
+	space(0);  // Always end with the Emulator on
+}
+
+//+=============================================================================
+// Sends an IR mark for the specified number of microseconds.
+// The mark output is modulated at the PWM frequency.
+//
+void  IRemulate::mark (unsigned int time)
+{
+	digitalWrite(emulatepin_, LOW); // Disable emulation pin output
+	if (time > 0) custom_delay_usec(time);
+}
+
+//+=============================================================================
+// Leave pin off for time (given in microseconds)
+// Sends an IR space for the specified number of microseconds.
+// A space is no output, so the PWM output is disabled.
+//
+void  IRemulate::space (unsigned int time)
+{
+	digitalWrite(emulatepin_, HIGH); // Enable emulation pin output
+	if (time > 0) custom_delay_usec(time);
+}
+
+
+
+
+
+//+=============================================================================
+// Enables emulation output.
+//
+void  IRemulate::enableIROut ()
+{
+	// Disable the Timer2 Interrupt (which is used for receiving IR)
+	TIMER_DISABLE_INTR; //Timer2 Overflow Interrupt
+
+	pinMode(emulatepin_, OUTPUT);
+	digitalWrite(emulatepin_, HIGH); // When not sending, we want it high
+}
+
+//+=============================================================================
+// Custom delay function that circumvents Arduino's delayMicroseconds limit
+
+void IRemulate::custom_delay_usec(unsigned long uSecs) {
+  if (uSecs > 4) {
+    unsigned long start = micros();
+    unsigned long endMicros = start + uSecs - 4;
+    if (endMicros < start) { // Check if overflow
+      while ( micros() > start ) {} // wait until overflow
+    }
+    while ( micros() < endMicros ) {} // normal wait
+  }
+  //else {
+  //  __asm__("nop\n\t"); // must have or compiler optimizes out
+  //}
+}

--- a/irEmulate.cpp
+++ b/irEmulate.cpp
@@ -10,7 +10,7 @@ IRemulate::IRemulate (int emulatepin, bool solesource)
 //+=============================================================================
 void  IRemulate::emulateRaw (const unsigned int buf[],  unsigned int len)
 {
-	// Set IR carrier frequency
+	// Manage outputs
 	enableIROut();
 
 	for (unsigned int i = 0;  i < len;  i++) {
@@ -23,7 +23,6 @@ void  IRemulate::emulateRaw (const unsigned int buf[],  unsigned int len)
 
 //+=============================================================================
 // Sends an IR mark for the specified number of microseconds.
-// The mark output is modulated at the PWM frequency.
 //
 void  IRemulate::mark (unsigned int time)
 {
@@ -32,9 +31,8 @@ void  IRemulate::mark (unsigned int time)
 }
 
 //+=============================================================================
-// Leave pin off for time (given in microseconds)
+// Leave pin on for time (given in microseconds)
 // Sends an IR space for the specified number of microseconds.
-// A space is no output, so the PWM output is disabled.
 //
 void  IRemulate::space (unsigned int time)
 {

--- a/irEmulate.cpp
+++ b/irEmulate.cpp
@@ -2,8 +2,8 @@
 #include "IRremoteInt.h"
 
 //+=============================================================================
-IRemulate::IRemulate (int emulatepin)
-: emulatepin_(emulatepin)
+IRemulate::IRemulate (int emulatepin, bool solesource)
+: emulatepin_(emulatepin), solesource_(solesource)
 {
 }
 
@@ -18,7 +18,7 @@ void  IRemulate::emulateRaw (const unsigned int buf[],  unsigned int len)
 		else        mark (buf[i]) ;
 	}
 
-	space(0);  // Always end with the Emulator on
+	disableIROut();
 }
 
 //+=============================================================================
@@ -56,6 +56,21 @@ void  IRemulate::enableIROut ()
 
 	pinMode(emulatepin_, OUTPUT);
 	digitalWrite(emulatepin_, HIGH); // When not sending, we want it high
+}
+
+//+=============================================================================
+// Disables emulation output.
+//
+void  IRemulate::disableIROut ()
+{
+	// Enable the Timer2 Interrupt (which is used for receiving IR)
+	TIMER_ENABLE_INTR; //Timer2 Overflow Interrupt
+
+	if (solesource_) {
+		space(0);  // Always end with the Emulator on
+	} else {
+		pinMode(emulatepin_, INPUT); // Enable high impedance on pin to allow actual receiver
+	}
 }
 
 //+=============================================================================

--- a/ir_NEC.cpp
+++ b/ir_NEC.cpp
@@ -41,7 +41,7 @@ void  IRemulate::emulateNEC (unsigned long data,  int nbits)
 
 	// Footer
 	mark(NEC_BIT_MARK);
-	space(0);  // Always end with the IR receiver on
+	disableIROut();
 }
 #endif
 

--- a/ir_NEC.cpp
+++ b/ir_NEC.cpp
@@ -18,6 +18,34 @@
 #define NEC_RPT_SPACE   2250
 
 //+=============================================================================
+#if EMULATE_NEC
+void  IRemulate::emulateNEC (unsigned long data,  int nbits)
+{
+	// Manage outputs
+	enableIROut();
+
+	// Header
+	mark(NEC_HDR_MARK);
+	space(NEC_HDR_SPACE);
+
+	// Data
+	for (unsigned long  mask = 1UL << (nbits - 1);  mask;  mask >>= 1) {
+		if (data & mask) {
+			mark(NEC_BIT_MARK);
+			space(NEC_ONE_SPACE);
+		} else {
+			mark(NEC_BIT_MARK);
+			space(NEC_ZERO_SPACE);
+		}
+	}
+
+	// Footer
+	mark(NEC_BIT_MARK);
+	space(0);  // Always end with the IR receiver on
+}
+#endif
+
+//+=============================================================================
 #if SEND_NEC
 void  IRsend::sendNEC (unsigned long data,  int nbits)
 {

--- a/keywords.txt
+++ b/keywords.txt
@@ -9,6 +9,7 @@
 decode_results	KEYWORD1
 IRrecv	KEYWORD1
 IRsend	KEYWORD1
+IRemulate	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -19,6 +20,7 @@ decode	KEYWORD2
 enableIRIn	KEYWORD2
 resume	KEYWORD2
 enableIROut	KEYWORD2
+
 sendNEC	KEYWORD2
 sendSony	KEYWORD2
 sendSanyo KEYWORD2
@@ -32,6 +34,20 @@ sendSharpRaw KEYWORD2
 sendPanasonic KEYWORD2
 sendJVC KEYWORD2
 sendLG KEYWORD2
+
+emulateNEC	KEYWORD2
+emulateSony	KEYWORD2
+emulateSanyo KEYWORD2
+emulateMitsubishi KEYWORD2
+emulateRaw	KEYWORD2
+emulateRC5	KEYWORD2
+emulateRC6	KEYWORD2
+emulateDISH KEYWORD2
+emulateSharp KEYWORD2
+emulateSharpRaw KEYWORD2
+emulatePanasonic KEYWORD2
+emulateJVC KEYWORD2
+emulateLG KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
With this pull request I have added the functionality of emulating the output of IR receiver. It's inspired from both personal requirements but also from several threads around the web (see below) asking for a possibility of either replacing an IR receiver with an Arduino or using an Arduino in tandem with a receiver.

Threads asking for this possibility, which also reference this library:

- [http://forum.arduino.cc/index.php?topic=233668.0](url)
- [https://forum.arduino.cc/index.php?topic=364932.0](url)
- [http://forum.arduino.cc/index.php?topic=263845.0](url)
- [http://forum.arduino.cc/index.php?topic=217116.0](url)
- [https://forum.arduino.cc/index.php?topic=481259.0](url)
- [https://stackoverflow.com/questions/37688951/arduino-timing-programming-for-nec-signal-output-on-wire](url)
- [https://arduino.stackexchange.com/questions/18569/sending-ir-nec-signals-with-arduino](url)

Along with my own project where I want to use the Arduino to issue commands to my Surround System while still maintaining the remote control for the system.

The `IRemulation` class is more or less a copy of the `IRsend` class, simply without PWM (only using `digitalWrite()`, which probably could be changed to register manipulation instead) and inverted mark/pause logic.

The implementation of using the emulator on top of an actual IR receiver should probably get a more user-friendly interface, but for now I think it will do. It's just a boolean flag `solesource` with a default value of `true` asking if the Arduino acts as the sole signal source of if it's among other signals on the same signal line.

**ONLY** the general architecture and NEC are implemented at the moment. No other protocol is implemented, but should be easy to implement later on.