### PR TITLE
Support for 64-bit data with RC6 protocol

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -80,6 +80,12 @@
 #define SEND_LEGO_PF         1
 
 //------------------------------------------------------------------------------
+// RC6 can have data longer than 32 bits. To conserve memory, support for
+// 64 bit data is disabled by default
+//
+#define RC6_64BIT        false
+
+//------------------------------------------------------------------------------
 // When sending a Pronto code we request to send either the "once" code
 //                                                   or the "repeat" code
 // If the code requested does not exist we can request to fallback on the
@@ -146,6 +152,15 @@ int  MATCH_MARK  (int measured_ticks, int desired_us) ;
 int  MATCH_SPACE (int measured_ticks, int desired_us) ;
 
 //------------------------------------------------------------------------------
+// Type used for storing decoded data
+//
+#if RC6_64BIT
+	typedef unsigned long long data_type_t;
+#else
+	typedef unsigned long data_type_t;
+#endif
+
+//------------------------------------------------------------------------------
 // Results returned from the decoder
 //
 class decode_results
@@ -153,7 +168,7 @@ class decode_results
 	public:
 		decode_type_t          decode_type;  // UNKNOWN, NEC, SONY, RC5, ...
 		unsigned int           address;      // Used by Panasonic & Sharp [16-bits]
-		unsigned long long     value;        // Decoded value [max 64-bits]
+		data_type_t            value;        // Decoded value [max 32 or 64-bits]
 		int                    bits;         // Number of bits in decoded value
 		volatile unsigned int  *rawbuf;      // Raw intervals in 50uS ticks
 		int                    rawlen;       // Number of records in rawbuf
@@ -272,7 +287,7 @@ class IRsend
 			void  sendRC5        (unsigned long data,  int nbits) ;
 #		endif
 #		if SEND_RC6
-			void  sendRC6        (unsigned long long data,  int nbits) ;
+			void  sendRC6        (data_type_t data,  int nbits) ;
 #		endif
 		//......................................................................
 #		if SEND_NEC

--- a/IRremote.h
+++ b/IRremote.h
@@ -153,7 +153,7 @@ class decode_results
 	public:
 		decode_type_t          decode_type;  // UNKNOWN, NEC, SONY, RC5, ...
 		unsigned int           address;      // Used by Panasonic & Sharp [16-bits]
-		unsigned long          value;        // Decoded value [max 32-bits]
+		unsigned long long     value;        // Decoded value [max 64-bits]
 		int                    bits;         // Number of bits in decoded value
 		volatile unsigned int  *rawbuf;      // Raw intervals in 50uS ticks
 		int                    rawlen;       // Number of records in rawbuf
@@ -272,7 +272,7 @@ class IRsend
 			void  sendRC5        (unsigned long data,  int nbits) ;
 #		endif
 #		if SEND_RC6
-			void  sendRC6        (unsigned long data,  int nbits) ;
+			void  sendRC6        (unsigned long long data,  int nbits) ;
 #		endif
 		//......................................................................
 #		if SEND_NEC

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -26,7 +26,8 @@ void setup()
 
 void loop() {
   if (irrecv.decode(&results)) {
-    Serial.println(results.value, HEX);
+    Serial.print((long)((results->value)>>32), HEX);
+    Serial.print((long)((results->value)& 0xFFFFFFFF), HEX);
     irrecv.resume(); // Receive the next value
   }
   delay(100);

--- a/examples/IRrecvDemo/IRrecvDemo.ino
+++ b/examples/IRrecvDemo/IRrecvDemo.ino
@@ -26,8 +26,8 @@ void setup()
 
 void loop() {
   if (irrecv.decode(&results)) {
-    Serial.print((long)((results->value)>>32), HEX);
-    Serial.print((long)((results->value)& 0xFFFFFFFF), HEX);
+    if (results.value > 0xFFFFFFFF) Serial.print((long)((results.value)>>32), HEX);
+    Serial.print((long)((results.value)& 0xFFFFFFFF), HEX);
     irrecv.resume(); // Receive the next value
   }
   delay(100);

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -65,7 +65,8 @@ void dump(decode_results *results) {
   else if (results->decode_type == WHYNTER) {
     Serial.print("Decoded Whynter: ");
   }
-  Serial.print(results->value, HEX);
+  Serial.print((long)((results->value)>>32), HEX);
+  Serial.print((long)((results->value)& 0xFFFFFFFF), HEX);
   Serial.print(" (");
   Serial.print(results->bits, DEC);
   Serial.println(" bits)");

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -65,7 +65,7 @@ void dump(decode_results *results) {
   else if (results->decode_type == WHYNTER) {
     Serial.print("Decoded Whynter: ");
   }
-  Serial.print((long)((results->value)>>32), HEX);
+  if (results->value > 0xFFFFFFFF) Serial.print((long)((results->value)>>32), HEX);
   Serial.print((long)((results->value)& 0xFFFFFFFF), HEX);
   Serial.print(" (");
   Serial.print(results->bits, DEC);

--- a/examples/IRrecvDump/IRrecvDump.ino
+++ b/examples/IRrecvDump/IRrecvDump.ino
@@ -85,11 +85,13 @@ void dump(decode_results *results) {
     Serial.print(" ");
   }
   Serial.println();
+
+  if (sizeof(results->value) * 8 < results->bits)
+    Serial.println("Warning: Decoded data too large, truncated. Consider enabling RC6_64BIT in IRremote.h.");
 }
 
 void loop() {
   if (irrecv.decode(&results)) {
-    Serial.println(results.value, HEX);
     dump(&results);
     irrecv.resume(); // Receive the next value
   }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -30,7 +30,9 @@ void  ircode (decode_results *results)
   }
 
   // Print Code
-  Serial.print(results->value, HEX);
+  Serial.print((long)((results->value) >> 32), HEX);
+  Serial.print((long)((results->value) & 0xFFFFFFFF), HEX);
+
 }
 
 //+=============================================================================
@@ -155,7 +157,8 @@ void  dumpCode (decode_results *results)
 
     // All protocols have data
     Serial.print("unsigned int  data = 0x");
-    Serial.print(results->value, HEX);
+    Serial.print((long)((results->value) >> 32), HEX);
+    Serial.print((long)((results->value) & 0xFFFFFFFF), HEX);
     Serial.println(";");
   }
 }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -30,7 +30,7 @@ void  ircode (decode_results *results)
   }
 
   // Print Code
-  Serial.print((long)((results->value) >> 32), HEX);
+  if (results->value > 0xFFFFFFFF) Serial.print((long)((results->value) >> 32), HEX);
   Serial.print((long)((results->value) & 0xFFFFFFFF), HEX);
 
 }
@@ -157,7 +157,7 @@ void  dumpCode (decode_results *results)
 
     // All protocols have data
     Serial.print("unsigned int  data = 0x");
-    Serial.print((long)((results->value) >> 32), HEX);
+    if (results->value > 0xFFFFFFFF) Serial.print((long)((results->value) >> 32), HEX);
     Serial.print((long)((results->value) & 0xFFFFFFFF), HEX);
     Serial.println(";");
   }

--- a/examples/IRrecvDumpV2/IRrecvDumpV2.ino
+++ b/examples/IRrecvDumpV2/IRrecvDumpV2.ino
@@ -174,6 +174,8 @@ void  loop ( )
     dumpInfo(&results);           // Output the results
     dumpRaw(&results);            // Output the results in RAW format
     dumpCode(&results);           // Output the results as source code
+    if (sizeof(results.value) * 8 < results.bits)
+      Serial.println("Warning: Decoded data too large, truncated. Consider enabling RC6_64BIT in IRremote.h.");
     Serial.println("");           // Blank line between entries
     irrecv.resume();              // Prepare for the next value
   }

--- a/ir_RC5_RC6.cpp
+++ b/ir_RC5_RC6.cpp
@@ -128,8 +128,14 @@ bool  IRrecv::decodeRC5 (decode_results *results)
 #define RC6_T1             444
 #define RC6_RPT_LENGTH   46000
 
+#if RC6_64BIT
+#	define MASK 1ULL
+#else
+#	define MASK 1UL
+#endif
+
 #if SEND_RC6
-void  IRsend::sendRC6 (unsigned long long data,  int nbits)
+void  IRsend::sendRC6 (data_type_t data,  int nbits)
 {
 	// Set IR carrier frequency
 	enableIROut(36);
@@ -143,7 +149,7 @@ void  IRsend::sendRC6 (unsigned long long data,  int nbits)
 	space(RC6_T1);
 
 	// Data
-	for (unsigned long long  i = 1, mask = 1ULL << (nbits - 1);  mask;  i++, mask >>= 1) {
+	for (data_type_t  i = 1, mask = MASK << (nbits - 1);  mask;  i++, mask >>= 1) {
 		// The fourth bit we send is a "double width trailer bit"
 		int  t = (i == 4) ? (RC6_T1 * 2) : (RC6_T1) ;
 		if (data & mask) {
@@ -164,7 +170,7 @@ void  IRsend::sendRC6 (unsigned long long data,  int nbits)
 bool  IRrecv::decodeRC6 (decode_results *results)
 {
 	int   nbits;
-	long long data   = 0;
+	data_type_t data   = 0;
 	int   used   = 0;
 	int   offset = 1;  // Skip first space
 

--- a/ir_RC5_RC6.cpp
+++ b/ir_RC5_RC6.cpp
@@ -129,7 +129,7 @@ bool  IRrecv::decodeRC5 (decode_results *results)
 #define RC6_RPT_LENGTH   46000
 
 #if SEND_RC6
-void  IRsend::sendRC6 (unsigned long data,  int nbits)
+void  IRsend::sendRC6 (unsigned long long data,  int nbits)
 {
 	// Set IR carrier frequency
 	enableIROut(36);
@@ -143,7 +143,7 @@ void  IRsend::sendRC6 (unsigned long data,  int nbits)
 	space(RC6_T1);
 
 	// Data
-	for (unsigned long  i = 1, mask = 1UL << (nbits - 1);  mask;  i++, mask >>= 1) {
+	for (unsigned long long  i = 1, mask = 1ULL << (nbits - 1);  mask;  i++, mask >>= 1) {
 		// The fourth bit we send is a "double width trailer bit"
 		int  t = (i == 4) ? (RC6_T1 * 2) : (RC6_T1) ;
 		if (data & mask) {
@@ -164,7 +164,7 @@ void  IRsend::sendRC6 (unsigned long data,  int nbits)
 bool  IRrecv::decodeRC6 (decode_results *results)
 {
 	int   nbits;
-	long  data   = 0;
+	long long data   = 0;
 	int   used   = 0;
 	int   offset = 1;  // Skip first space
 


### PR DESCRIPTION
Resolves #564.
Tested only with Arduino UNO and Asus remote

The code adds a 
```
#define RC6_64BIT        false
``` 
to `IRremote.h`. Enabling it allows output data/value to be `long long` type variable (usually 64-bit). To make code simple and not to put many #if's in the code it defines a type `data_type_t`, which can be either `unsigned long` or `unsigned long long`. It is used in the class `decode_results` but only `sendRC6` function was changed to accept that data. I don't know anything about other protocols to mess with them. 

`IRrecv*` examples were updated to support it, but I didn't put preprocessor directives to disable handling of longer data. It results in an additional warning during compilation, but I think it is better to preserve code simplicity. Regretfully standard `Serial.print` functions don't support `long long` data... I also added a warning if received data is too long to fit into the variable.

Memory footprint: enabling 64 bit support increases the size of `IRrecvDumpV2` compiled sketch from `8658` to `9122` (but I don't know why code before modifications used a bit more: `8682` even though sketch now has a bit more code).