### PR TITLE
API allowing disabling the timer interrupt.

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -176,6 +176,9 @@ class IRrecv
 
 		void  blink13    (int blinkflag) ;
 		int   decode     (decode_results *results) ;
+#ifdef ESP32
+		void  disableIRIn( ) ;
+#endif
 		void  enableIRIn ( ) ;
 		bool  isIdle     ( ) ;
 		void  resume     ( ) ;

--- a/irRecv.cpp
+++ b/irRecv.cpp
@@ -116,6 +116,15 @@ IRrecv::IRrecv (int recvpin, int blinkpin)
 }
 
 
+#ifdef ESP32
+//+=============================================================================
+// disabling the timer
+//
+void  IRrecv::disableIRIn ( )
+{
+	timerAlarmDisable(timer);
+}
+#endif
 
 //+=============================================================================
 // initialization


### PR DESCRIPTION
The ESP32 seems to be sensitive towards interrupts while an OTA update is running. After I call `enableIRIn()`, I can't get a successful OTA-Update any longer. The reason seems to be the timerinterrupt set up by IRRecv.

I now simply deactivate IRRecv once an update is being run like this:

```
ArduinoOTA.onStart([&]() {
  irrecv.disableIRIn(); // the new api contained in this pull request.
  Serial.println("Receiving Update");
});
```
