### PR TITLE
Atmega4809 board definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The following are strictly community supported patches that have yet to make it 
 
 [Arduino 101](https://github.com/z3t0/Arduino-IRremote/pull/481#issuecomment-311243146)
 
+[ATmega4809 -> Nano Every & UNO WiFi Rev2](https://github.com/mklemenz/Arduino-IRremote) (Send Pin 24, Timer TCB0)
+
 The table above lists the currently supported timers and corresponding send pins, many of these can have additional pins opened up and we are open to requests if a need arises for other pins.
 
 ## Usage

--- a/boarddefs.h
+++ b/boarddefs.h
@@ -597,7 +597,7 @@
   TCB0.CTRLA = (TCB_CLKSEL_CLKDIV1_gc) | (TCB_ENABLE_bm); \
 })
 
-#define TIMER_PWM_PIN        24  /* Uno Every */
+#define TIMER_PWM_PIN        6  /* Nano Every, Uno WiFi Rev2 */
 
 
 //---------------------------------------------------------


### PR DESCRIPTION
This patch should work for the new boards "Nano Every" and "UNO WiFi Rev2" from Arduino.
I have tested receiving IR signals and it works. But since I currently don't have IR emitters/diodes at hand, consider the code necessary for sending signals as experimental.

It fixes the compiler errors mentioned in the issues #639 and #641 as well.