### PR TITLE
typo: removes useless spaces in cotnributors.md

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,17 +1,17 @@
 ## Contributors
 These are the active contributors of this project that you may contact if there is anything you need help with or if you have suggestions.
 
-- [z3t0](https://github.com/z3t0) : Active Contributor and currently also the main contributor.
+- [z3t0](https://github.com/z3t0): Active Contributor and currently also the main contributor.
   * Email: zetoslab@gmail.com
-- [shirriff](https://github.com/shirriff) : An amazing person who worked to create this awesome library and provide unending support
+- [shirriff](https://github.com/shirriff): An amazing person who worked to create this awesome library and provide unending support
 - [AnalysIR](https:/github.com/AnalysIR): Active contributor and is amazing with providing support!
-- [Informatic](https://github.com/Informatic) : Active contributor
-- [fmeschia](https://github.com/fmeschia) : Active contributor
+- [Informatic](https://github.com/Informatic): Active contributor
+- [fmeschia](https://github.com/fmeschia): Active contributor
 - [PaulStoffregen](https://github.com/paulstroffregen) : Active contributor
-- [crash7](https://github.com/crash7) : Active contributor
-- [Neco777](https://github.com/neco777) : Active contributor
-- [Lauszus](https://github.com/lauszus) : Active contributor
-- [csBlueChip](https://github.com/csbluechip) : Active contributor, who contributed major and vital changes to the code base.
+- [crash7](https://github.com/crash7): Active contributor
+- [Neco777](https://github.com/neco777): Active contributor
+- [Lauszus](https://github.com/lauszus): Active contributor
+- [csBlueChip](https://github.com/csbluechip): Active contributor, who contributed major and vital changes to the code base.
 - [Sebazzz](https://github.com/sebazz): Contributor
 - [lumbric](https://github.com/lumbric): Contributor
 - [ElectricRCAircraftGuy](https://github.com/electricrcaircraftguy): Active Contributor


### PR DESCRIPTION
A really small pull request because I noticed useless spaces before ':'