### PR TITLE
Fix warnings for block-scope issues

### DIFF
--- a/IRremote.h
+++ b/IRremote.h
@@ -131,11 +131,11 @@ decode_type_t;
 // Debug directives
 //
 #if DEBUG
-#	define DBG_PRINT(...)    Serial.print(__VA_ARGS__)
-#	define DBG_PRINTLN(...)  Serial.println(__VA_ARGS__)
+#	define DBG_PRINT(...)    do { Serial.print(__VA_ARGS__); } while (0)
+#	define DBG_PRINTLN(...)  do { Serial.println(__VA_ARGS__); } while (0)
 #else
-#	define DBG_PRINT(...)
-#	define DBG_PRINTLN(...)
+#	define DBG_PRINT(...)    do { } while (0)
+#	define DBG_PRINTLN(...)  do { } while (0)
 #endif
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
With no debugging enabled, DBG_PRINT() and DBG_PRINTLN() are just
empty and in code like this:

	if (foo)
		DBG_PRINT();
	else
		DBG_PRINT();

it will result in

	if (foo)
		/* nothing */;
	else
		/* nothing */;

Macros that are used in a function-alike way should always result in
something that looks like exactly one single statement.

/opt/arduino/arduino-1.8.10/hardware/tools/avr/bin/avr-g++ -MMD -c -mmcu=atmega32u4 -DF_CPU=16000000L -DARDUINO=1810 -DARDUINO_ARCH_AVR -D__PROG_TYPES_COMPAT__ -I/opt/arduino/arduino-1.8.10/hardware/arduino/avr/cores/arduino -I/opt/arduino/arduino-1.8.10/hardware/arduino/avr/variants/leonardo    -I/opt/arduino/arduino-1.8.10/libraries/Keyboard/src   -I/opt/arduino/arduino-1.8.10/hardware/arduino/avr/libraries/HID/src   -I./sketchbook/libraries/Arduino-IRremote -Wall -ffunction-sections -fdata-sections -Os -DUSB_VID=0x2341 -DUSB_PID=0x8036 -fpermissive -fno-exceptions -std=gnu++11 -fno-threadsafe-statics -flto -Wall               -std=gnu++11 -fno-threadsafe-statics  -DSPECIAL_IMANUFACTURER="\"Getslash\"" -DSPECIAL_IPRODUCT="\"GSDongle-gff23ecc\"" -DSPECIAL_ISERIAL="\"00000000-\"" sketchbook/libraries/Arduino-IRremote/IRremote.cpp -o build-leonardo/userlibs/Arduino-IRremote/IRremote.cpp.o
sketchbook/libraries/Arduino-IRremote/IRremote.cpp: In function 'int MATCH(int, int)':
sketchbook/libraries/Arduino-IRremote/IRremote.cpp:57:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
   else
   ^~~~
sketchbook/libraries/Arduino-IRremote/IRremote.cpp:59:3: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
   return passed;
   ^~~~~~
sketchbook/libraries/Arduino-IRremote/IRremote.cpp: In function 'int MATCH_MARK(int, int)':
sketchbook/libraries/Arduino-IRremote/IRremote.cpp:83:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
   else
   ^~~~
sketchbook/libraries/Arduino-IRremote/IRremote.cpp:85:3: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
   return passed;
   ^~~~~~
sketchbook/libraries/Arduino-IRremote/IRremote.cpp: In function 'int MATCH_SPACE(int, int)':
sketchbook/libraries/Arduino-IRremote/IRremote.cpp:109:3: warning: this 'else' clause does not guard... [-Wmisleading-indentation]
   else
   ^~~~
sketchbook/libraries/Arduino-IRremote/IRremote.cpp:111:3: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'else'
   return passed;
   ^~~~~~