### PR TITLE
Resolves undefined reference error when calling sendPronto

### DIFF
--- a/irPronto.cpp
+++ b/irPronto.cpp
@@ -1,24 +1,6 @@
-#define TEST 0
-
-#if TEST
-#	define SEND_PRONTO        1
-#	define PRONTO_ONCE        false
-#	define PRONTO_REPEAT      true
-#	define PRONTO_FALLBACK    true
-#	define PRONTO_NOFALLBACK  false
-#endif
+#include "IRremote.h"
 
 #if SEND_PRONTO
-
-//******************************************************************************
-#if TEST
-#	include <stdio.h>
-	void  enableIROut (int freq)  { printf("\nFreq = %d KHz\n", freq); }
-	void  mark        (int t)     { printf("+%d," , t); }
-	void  space       (int t)     { printf("-%d, ", t); }
-#else
-#	include "IRremote.h"
-#endif // TEST
 
 //+=============================================================================
 // Check for a valid hex digit
@@ -70,7 +52,7 @@ uint16_t  htow (char* cp)
 
 //+=============================================================================
 //
-bool sendPronto (char* s,  bool repeat,  bool fallback)
+void  IRsend::sendPronto (char* s,  bool repeat,  bool fallback)
 {
 	int       i;
 	int       len;


### PR DESCRIPTION
There may be a better way to fix this issue, but here's what I've done.

When you follow the example code like IRSendDemo.ino, you call a function like this:
irsend.sendSony

This wasn't working for sendPronto. When I did an irsend.sendPronto, the Arduino IDE would generate the following error:
undefined reference to `IRsend::sendPronto(char*, bool, bool)'

There were two issues.  IRremote.h defines the send function to return void, and the sendPronto in irPronto.cpp returns bool.

Second, just the way the TEST code in sendPronto was setup, IRremote.h wasn't getting included, and it was missing the:
#define SEND_PRONTO          1