### PR TITLE
Some minor cleanup on the new MagiQuest module

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -22,5 +22,6 @@ These are the active contributors of this project that you may contact if there 
 - [bengtmartensson](https://github.com/bengtmartensson) providing support
 - [AnalysIR](https:/github.com/AnalysIR) providing support
 - [ArminJo](https://github.com/ArminJo) Maintainer
+- [eshicks4](https://github.com/eshicks4)
 
 Note: Please let [z3t0](https://github.com/z3t0) know if you have been missed.

--- a/src/ir_MagiQuest.cpp
+++ b/src/ir_MagiQuest.cpp
@@ -1,5 +1,4 @@
 #include "IRremote.h"
-#include <math.h>
 
 // Based off the Magiquest fork of Arduino-IRremote by mpflaga
 // https://github.com/mpflaga/Arduino-IRremote/
@@ -15,7 +14,6 @@
 // MagiQuest packet is both Wand ID and magnitude of swish and flick
 union magiquest_t {
     unsigned long long llword;
-    unsigned char byte[8];
     struct {
         unsigned int magnitude;
         unsigned long wand_id;
@@ -34,10 +32,12 @@ union magiquest_t {
  *     1150 * 0.5 = 575 usec mark
  *     1150 - 575 = 575 usec space
  */
-#define MAGIQUEST_ONE_MARK 575
-#define MAGIQUEST_ONE_SPACE 575
-#define MAGIQUEST_ZERO_MARK 288
-#define MAGIQUEST_ZERO_SPACE 862
+#define MAGIQUEST_ONE_MARK    575
+#define MAGIQUEST_ONE_SPACE   575
+#define MAGIQUEST_ZERO_MARK   288
+#define MAGIQUEST_ZERO_SPACE  862
+
+#define MAGIQUEST_MASK        (1ULL << (MAGIQUEST_BITS-1))
 
 //+=============================================================================
 //
@@ -53,18 +53,18 @@ void IRsend::sendMagiQuest(unsigned long wand_id, unsigned int magnitude) {
     enableIROut(38);
 
     // Data
-    for (unsigned long long mask = (unsigned long long)pow(2, MAGIQUEST_BITS-1); mask > 0; mask >>= 1) {
+    for (unsigned long long mask = MAGIQUEST_MASK; mask > 0; mask >>= 1) {
         if (data.llword & mask) {
-        	DBG_PRINT("1");
+            DBG_PRINT("1");
             mark(MAGIQUEST_ONE_MARK);
             space(MAGIQUEST_ONE_SPACE);
         } else {
-        	DBG_PRINT("0");
+            DBG_PRINT("0");
             mark(MAGIQUEST_ZERO_MARK);
             space(MAGIQUEST_ZERO_SPACE);
         }
     }
-	DBG_PRINTLN("");
+    DBG_PRINTLN("");
 
     // Footer
     mark(MAGIQUEST_ZERO_MARK);
@@ -127,8 +127,8 @@ bool IRrecv::decodeMagiQuest(decode_results *results) {
 #endif
             }
         } else {
-        	DBG_PRINTLN("MATCH_MARK failed");
-        	return false;
+            DBG_PRINTLN("MATCH_MARK failed");
+            return false;
         }
     }
 #if DEBUG
@@ -141,12 +141,12 @@ bool IRrecv::decodeMagiQuest(decode_results *results) {
     results->value = data.cmd.wand_id;
     results->magnitude = data.cmd.magnitude;
 
-   	DBG_PRINT("MQ: bits=");
-   	DBG_PRINT(results->bits);
-   	DBG_PRINT(" value=");
-   	DBG_PRINT(results->value);
-   	DBG_PRINT(" magnitude=");
-   	DBG_PRINTLN(results->magnitude);
+    DBG_PRINT("MQ: bits=");
+    DBG_PRINT(results->bits);
+    DBG_PRINT(" value=");
+    DBG_PRINT(results->value);
+    DBG_PRINT(" magnitude=");
+    DBG_PRINTLN(results->magnitude);
 
     return true;
 }


### PR DESCRIPTION
Some minor cleanup on the new MagiQuest module

- Switched initial mask value calc to use the compiler preprocessor instead of code requiring pow() from math.h
- Cleaned up the per-byte magiquest_t bit of the union since new mods don't use it
- Fixed a few tabs I missed the 1st time as per the contributing doc
- Added myself to the bottom of the contributor list
