### PR TITLE
Fix multiplication overflows

### DIFF
--- a/src/ir_Sanyo.cpp
+++ b/src/ir_Sanyo.cpp
@@ -38,7 +38,7 @@ bool IRrecv::decodeSanyo() {
 #endif
 
 // Initial space
-    if ((results.rawbuf[offset] * MICROS_PER_TICK) < SANYO_DOUBLE_SPACE_USECS) {
+    if (results.rawbuf[offset] < SANYO_DOUBLE_SPACE_USECS / MICROS_PER_TICK) {
         //Serial.print("IR Gap found: ");
         results.bits = 0;
         results.value = REPEAT;

--- a/src/ir_Sony.cpp
+++ b/src/ir_Sony.cpp
@@ -54,7 +54,7 @@ bool IRrecv::decodeSony() {
 
     // Some Sony's deliver repeats fast after first
     // unfortunately can't spot difference from of repeat from two fast clicks
-    if (results.rawbuf[offset] * MICROS_PER_TICK < SONY_DOUBLE_SPACE_USECS) {
+    if (results.rawbuf[offset] < SONY_DOUBLE_SPACE_USECS / MICROS_PER_TICK) {
         DBG_PRINTLN("IR Gap found");
         results.bits = 0;
         results.value = REPEAT;


### PR DESCRIPTION
Multiplying two 16-bit integers can yield a result that does not fit
in a 16-bit integer, causing overflow and result in wrong result.
Fixing a couple of places that this can happen.